### PR TITLE
ssh-key: bump clippy to Rust 1.64

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.57.0
+          toolchain: 1.64.0
           components: clippy
           override: true
           profile: minimal

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -67,7 +67,7 @@ impl MPInt {
     pub fn from_positive_bytes(bytes: &[u8]) -> Result<Self> {
         let mut inner = Vec::with_capacity(bytes.len());
 
-        match bytes.get(0).cloned() {
+        match bytes.first().cloned() {
             Some(0) => return Err(Error::FormatEncoding),
             Some(n) if n >= 0x80 => inner.push(0),
             _ => (),

--- a/ssh-key/src/reader.rs
+++ b/ssh-key/src/reader.rs
@@ -62,7 +62,7 @@ pub(crate) trait Reader: Sized {
         self.read_nested(|reader| {
             let slice = out.get_mut(..reader.remaining_len()).ok_or(Error::Length)?;
             reader.read(slice)?;
-            Ok(&slice[..])
+            Ok(slice as &[u8])
         })
     }
 


### PR DESCRIPTION
Ensures the code is clippy-clean on the latest stable Rust release