### PR TITLE
README.md(s): update links to Zulip stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # "badges"
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
-[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [deps-image]: https://deps.rs/repo/github/RustCrypto/SSH/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/SSH
 

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -108,7 +108,7 @@ dual licensed as above, without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
-[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-key.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-key.yml
 


### PR DESCRIPTION
There's now an SSH-specific Zulip stream:

https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH