### PR TITLE
Cargo.toml: bump `rust-version` to 1.60

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["authentication", "cryptography", "encoding", "no-std", "parser-im
 keywords = ["crypto", "certificate", "key", "openssh", "ssh"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 base64ct = "1.4"


### PR DESCRIPTION
The MSRV was bumped in #16, however that PR did not bump `rust-version`.