### PR TITLE
Bump `rsa` to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981bbf816bc9b572f90289a88a40fece97d096e68f3f26d7c0c45cf1f1c65790"
+checksum = "96144aaefe4fa4c1846c404d1ccc3dc45c9b15c2e41591597294cb7ccc2dbfd7"
 dependencies = [
  "byteorder",
  "digest 0.10.5",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.4",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -29,7 +29,7 @@ bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, features = ["u64_backend"] }
 p256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6", optional = true, default-features = false }
-rsa = { version = "=0.7.0-rc.1", optional = true }
+rsa = { version = "0.7", optional = true }
 sec1 = { version = "0.3", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }


### PR DESCRIPTION
Changelog: https://github.com/RustCrypto/RSA/pull/211