### PR TITLE
ssh-key: `p384` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +705,7 @@ dependencies = [
  "ed25519-dalek",
  "hex-literal",
  "p256",
+ "p384",
  "pem-rfc7468",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -716,9 +728,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -759,9 +771,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-xid"

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -28,6 +28,7 @@ ctr = { version = "0.9", optional = true, default-features = false }
 bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, features = ["u64_backend"] }
 p256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6", optional = true, default-features = false }
 rsa = { version = "0.7", optional = true }
 sec1 = { version = "0.3", optional = true, default-features = false, features = ["point"] }
@@ -45,7 +46,17 @@ zeroize_derive = "1.3" # hack to make minimal-versions lint happy (pulled in by 
 [features]
 default = ["ecdsa", "fingerprint", "std", "rand_core"]
 alloc = ["base64ct/alloc", "signature", "zeroize/alloc"]
-std = ["alloc", "base64ct/std", "ed25519-dalek?/std", "p256?/std", "rsa?/std", "sec1?/std", "signature?/std"]
+std = [
+    "alloc",
+    "base64ct/std",
+    "ed25519-dalek?/std",
+    "p256?/std",
+    "p384?/std",
+    "pem-rfc7468/std",
+    "rsa?/std",
+    "sec1?/std",
+    "signature?/std"
+]
 
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -452,7 +452,7 @@ impl PrivateKey {
     pub fn random(mut rng: impl CryptoRng + RngCore, algorithm: Algorithm) -> Result<Self> {
         let checkint = rng.next_u32();
         let key_data = match algorithm {
-            #[cfg(feature = "p256")]
+            #[cfg(any(feature = "p256", feature = "p384"))]
             Algorithm::Ecdsa { curve } => KeypairData::from(EcdsaKeypair::random(rng, curve)?),
             #[cfg(feature = "ed25519")]
             Algorithm::Ed25519 => KeypairData::from(Ed25519Keypair::random(rng)),

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -120,6 +120,16 @@ impl From<p256::SecretKey> for EcdsaPrivateKey<32> {
     }
 }
 
+#[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
+impl From<p384::SecretKey> for EcdsaPrivateKey<48> {
+    fn from(sk: p384::SecretKey) -> EcdsaPrivateKey<48> {
+        EcdsaPrivateKey {
+            bytes: sk.to_be_bytes().into(),
+        }
+    }
+}
+
 #[cfg(feature = "subtle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "subtle")))]
 impl<const SIZE: usize> ConstantTimeEq for EcdsaPrivateKey<SIZE> {
@@ -184,6 +194,15 @@ impl EcdsaKeypair {
                 let private = p256::SecretKey::random(rng);
                 let public = private.public_key();
                 Ok(EcdsaKeypair::NistP256 {
+                    private: private.into(),
+                    public: public.into(),
+                })
+            }
+            #[cfg(feature = "p384")]
+            EcdsaCurve::NistP384 => {
+                let private = p384::SecretKey::random(rng);
+                let public = private.public_key();
+                Ok(EcdsaKeypair::NistP384 {
                     private: private.into(),
                     public: public.into(),
                 })

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -165,6 +165,16 @@ impl TryFrom<EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
     }
 }
 
+#[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
+impl TryFrom<EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
+    type Error = Error;
+
+    fn try_from(key: EcdsaPublicKey) -> Result<p384::ecdsa::VerifyingKey> {
+        p384::ecdsa::VerifyingKey::try_from(&key)
+    }
+}
+
 #[cfg(feature = "p256")]
 #[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<&EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
@@ -174,6 +184,21 @@ impl TryFrom<&EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
         match public_key {
             EcdsaPublicKey::NistP256(key) => {
                 p256::ecdsa::VerifyingKey::from_encoded_point(key).map_err(|_| Error::Crypto)
+            }
+            _ => Err(Error::Algorithm),
+        }
+    }
+}
+
+#[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
+impl TryFrom<&EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
+    type Error = Error;
+
+    fn try_from(public_key: &EcdsaPublicKey) -> Result<p384::ecdsa::VerifyingKey> {
+        match public_key {
+            EcdsaPublicKey::NistP384(key) => {
+                p384::ecdsa::VerifyingKey::from_encoded_point(key).map_err(|_| Error::Crypto)
             }
             _ => Err(Error::Algorithm),
         }
@@ -193,5 +218,21 @@ impl From<p256::ecdsa::VerifyingKey> for EcdsaPublicKey {
 impl From<&p256::ecdsa::VerifyingKey> for EcdsaPublicKey {
     fn from(key: &p256::ecdsa::VerifyingKey) -> EcdsaPublicKey {
         EcdsaPublicKey::NistP256(key.to_encoded_point(false))
+    }
+}
+
+#[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
+impl From<p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
+    fn from(key: p384::ecdsa::VerifyingKey) -> EcdsaPublicKey {
+        EcdsaPublicKey::from(&key)
+    }
+}
+
+#[cfg(feature = "p384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
+impl From<&p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
+    fn from(key: &p384::ecdsa::VerifyingKey) -> EcdsaPublicKey {
+        EcdsaPublicKey::NistP384(key.to_encoded_point(false))
     }
 }


### PR DESCRIPTION
Adds initial integration with the `p384` crate, including support for converting public and private keys to `p384` keys, as well as signing and verifying NIST P-384 signatures.