### PR TITLE
ssh-key: DSA support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22060e690a47585cff262a5a352241bb7536590cd5f7e9c2a223839ea14e9cf5"
+dependencies = [
+ "digest 0.10.5",
+ "num-bigint-dig",
+ "num-traits",
+ "opaque-debug",
+ "pkcs8",
+ "rand 0.8.5",
+ "rfc6979",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +389,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
+ "serde",
  "smallvec",
  "zeroize",
 ]
@@ -517,6 +535,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -639,6 +658,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.5",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,8 +732,10 @@ dependencies = [
  "base64ct",
  "bcrypt-pbkdf",
  "ctr",
+ "dsa",
  "ed25519-dalek",
  "hex-literal",
+ "num-bigint-dig",
  "p256",
  "p384",
  "pem-rfc7468",
@@ -712,6 +744,7 @@ dependencies = [
  "rsa",
  "sec1",
  "serde",
+ "sha1",
  "sha2 0.10.6",
  "signature",
  "subtle",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -26,6 +26,8 @@ zeroize = { version = "1", default-features = false }
 aes = { version = "0.8", optional = true, default-features = false }
 ctr = { version = "0.9", optional = true, default-features = false }
 bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
+bigint = { package = "num-bigint-dig", version = "0.8", optional = true }
+dsa = { version = "0.4.1", optional = true, default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, features = ["u64_backend"] }
 p256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
@@ -33,6 +35,7 @@ rand_core = { version = "0.6", optional = true, default-features = false }
 rsa = { version = "0.7", optional = true }
 sec1 = { version = "0.3", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
+sha1 = { version = "0.10", optional = true, default-features = false }
 sha2 = { version = "0.10.6", optional = true, default-features = false, features = ["oid"] }
 signature = { version = "1.6.4", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
@@ -58,11 +61,13 @@ std = [
     "signature?/std"
 ]
 
+dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "getrandom", "signature/rand-preview"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [ "alloc", "dep:aes", "dep:bcrypt-pbkdf", "dep:ctr", "rand_core"]
 fingerprint = ["dep:sha2"]
 getrandom = ["rand_core/getrandom"]
+rsa = ["dep:bigint", "dep:rsa"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -65,9 +65,9 @@ respective SSH key algorithm.
 | Name                                 | Decode | Encode | Cert | Keygen | Sign | Verify | Feature   | `no_std` |
 |--------------------------------------|--------|--------|------|--------|------|--------|-----------|----------|
 | `ecdsa‑sha2‑nistp256`                | ✅     | ✅     | ✅   | ✅️     | ✅️   | ✅️     | `p256`    | heapless |
-| `ecdsa‑sha2‑nistp384`                | ✅     | ✅     | ✅   | ⛔️     | ⛔️   | ⛔️     | ⛔        | heapless |
+| `ecdsa‑sha2‑nistp384`                | ✅     | ✅     | ✅   | ✅️     | ✅️   | ✅️     | `p384`    | heapless |
 | `ecdsa‑sha2‑nistp521`                | ✅     | ✅     | ✅   | ⛔️     | ⛔ ️  | ⛔️     | ⛔        | heapless |
-| `ssh‑dsa`                            | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ⛔️     | ⛔        | `alloc` ️ |
+| `ssh‑dsa`                            | ✅     | ✅     | ✅   | ✅     | ✅️   | ✅️     | `dsa`     | `alloc` ️ |
 | `ssh‑ed25519`                        | ✅     | ✅     | ✅   | ✅️     | ✅️   | ✅     | `ed25519` | heapless |
 | `ssh‑rsa`                            | ✅     | ✅     | ✅   | ✅️     | ✅️   | ✅     | `rsa`     | `alloc`  |
 | `sk‑ecdsa‑sha2‑nistp256@openssh.com` | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ⛔️     | ⛔        | `alloc`  |

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use core::fmt;
 use zeroize::Zeroize;
 
-#[cfg(feature = "rsa")]
+#[cfg(any(feature = "dsa", feature = "rsa"))]
 use zeroize::Zeroizing;
 
 #[cfg(feature = "subtle")]
@@ -180,46 +180,46 @@ impl fmt::UpperHex for MPInt {
     }
 }
 
-#[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
-impl TryFrom<rsa::BigUint> for MPInt {
+#[cfg(any(feature = "dsa", feature = "rsa"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
+impl TryFrom<bigint::BigUint> for MPInt {
     type Error = Error;
 
-    fn try_from(uint: rsa::BigUint) -> Result<MPInt> {
+    fn try_from(uint: bigint::BigUint) -> Result<MPInt> {
         MPInt::try_from(&uint)
     }
 }
 
-#[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
-impl TryFrom<&rsa::BigUint> for MPInt {
+#[cfg(any(feature = "dsa", feature = "rsa"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
+impl TryFrom<&bigint::BigUint> for MPInt {
     type Error = Error;
 
-    fn try_from(uint: &rsa::BigUint) -> Result<MPInt> {
+    fn try_from(uint: &bigint::BigUint) -> Result<MPInt> {
         let bytes = Zeroizing::new(uint.to_bytes_be());
         MPInt::from_positive_bytes(bytes.as_slice())
     }
 }
 
-#[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
-impl TryFrom<MPInt> for rsa::BigUint {
+#[cfg(any(feature = "dsa", feature = "rsa"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
+impl TryFrom<MPInt> for bigint::BigUint {
     type Error = Error;
 
-    fn try_from(mpint: MPInt) -> Result<rsa::BigUint> {
-        rsa::BigUint::try_from(&mpint)
+    fn try_from(mpint: MPInt) -> Result<bigint::BigUint> {
+        bigint::BigUint::try_from(&mpint)
     }
 }
 
-#[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
-impl TryFrom<&MPInt> for rsa::BigUint {
+#[cfg(any(feature = "dsa", feature = "rsa"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
+impl TryFrom<&MPInt> for bigint::BigUint {
     type Error = Error;
 
-    fn try_from(mpint: &MPInt) -> Result<rsa::BigUint> {
+    fn try_from(mpint: &MPInt) -> Result<bigint::BigUint> {
         mpint
             .as_positive_bytes()
-            .map(rsa::BigUint::from_bytes_be)
+            .map(bigint::BigUint::from_bytes_be)
             .ok_or(Error::Crypto)
     }
 }

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -7,6 +7,9 @@ use crate::{
 use core::fmt;
 use zeroize::Zeroize;
 
+#[cfg(feature = "dsa")]
+use crate::Error;
+
 #[cfg(feature = "subtle")]
 use subtle::{Choice, ConstantTimeEq};
 
@@ -68,6 +71,48 @@ impl Encode for DsaPrivateKey {
 impl fmt::Debug for DsaPrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DsaPrivateKey").finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<DsaPrivateKey> for dsa::BigUint {
+    type Error = Error;
+
+    fn try_from(key: DsaPrivateKey) -> Result<dsa::BigUint> {
+        dsa::BigUint::try_from(&key.inner)
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<&DsaPrivateKey> for dsa::BigUint {
+    type Error = Error;
+
+    fn try_from(key: &DsaPrivateKey) -> Result<dsa::BigUint> {
+        dsa::BigUint::try_from(&key.inner)
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<dsa::SigningKey> for DsaPrivateKey {
+    type Error = Error;
+
+    fn try_from(key: dsa::SigningKey) -> Result<DsaPrivateKey> {
+        DsaPrivateKey::try_from(&key)
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<&dsa::SigningKey> for DsaPrivateKey {
+    type Error = Error;
+
+    fn try_from(key: &dsa::SigningKey) -> Result<DsaPrivateKey> {
+        Ok(DsaPrivateKey {
+            inner: key.x().try_into()?,
+        })
     }
 }
 
@@ -138,6 +183,52 @@ impl fmt::Debug for DsaKeypair {
         f.debug_struct("DsaKeypair")
             .field("public", &self.public)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<DsaKeypair> for dsa::SigningKey {
+    type Error = Error;
+
+    fn try_from(key: DsaKeypair) -> Result<dsa::SigningKey> {
+        dsa::SigningKey::try_from(&key)
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<&DsaKeypair> for dsa::SigningKey {
+    type Error = Error;
+
+    fn try_from(key: &DsaKeypair) -> Result<dsa::SigningKey> {
+        Ok(dsa::SigningKey::from_components(
+            dsa::VerifyingKey::try_from(&key.public)?,
+            dsa::BigUint::try_from(&key.private)?,
+        )?)
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<dsa::SigningKey> for DsaKeypair {
+    type Error = Error;
+
+    fn try_from(key: dsa::SigningKey) -> Result<DsaKeypair> {
+        DsaKeypair::try_from(&key)
+    }
+}
+
+#[cfg(feature = "dsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
+impl TryFrom<&dsa::SigningKey> for DsaKeypair {
+    type Error = Error;
+
+    fn try_from(key: &dsa::SigningKey) -> Result<DsaKeypair> {
+        Ok(DsaKeypair {
+            private: key.try_into()?,
+            public: key.verifying_key().try_into()?,
+        })
     }
 }
 


### PR DESCRIPTION
Adds an initial integration with the `dsa` crate including conversions to/from key types as well as signing and verification support.