### PR TITLE
ssh-key: use deterministic `dsa` API

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -61,7 +61,7 @@ std = [
     "signature?/std"
 ]
 
-dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "getrandom", "signature/rand-preview"]
+dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "signature/rand-preview"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [ "alloc", "dep:aes", "dep:bcrypt-pbkdf", "dep:ctr", "rand_core"]

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -14,9 +14,8 @@ use crate::{private::Ed25519Keypair, public::Ed25519PublicKey};
 #[cfg(feature = "dsa")]
 use {
     crate::{private::DsaKeypair, public::DsaPublicKey},
-    rand_core::OsRng,
     sha1::{Digest, Sha1},
-    signature::{DigestVerifier, RandomizedDigestSigner, Signature as _},
+    signature::{DigestSigner, DigestVerifier, Signature as _},
 };
 
 #[cfg(any(feature = "p256", feature = "p384"))]
@@ -255,7 +254,7 @@ impl Verifier<Signature> for public::KeyData {
 impl Signer<Signature> for DsaKeypair {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         let data = dsa::SigningKey::try_from(self)?
-            .try_sign_digest_with_rng(OsRng, Sha1::new_with_prefix(message))
+            .try_sign_digest(Sha1::new_with_prefix(message))
             .map_err(|_| signature::Error::new())?;
 
         Ok(Signature {


### PR DESCRIPTION
Eliminates the need for the `getrandom` feature in order to use `dsa`.

Uses RFC6979 deterministic DSA instead.