### PR TITLE
Rename `*nested*` to `*prefixed*`

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -98,7 +98,7 @@ impl<const N: usize> Decode for [u8; N] {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        reader.read_nested(|reader| {
+        reader.read_prefixed(|reader| {
             let mut result = [(); N].map(|_| 0);
             reader.read(&mut result)?;
             Ok(result)
@@ -119,7 +119,7 @@ impl Decode for Vec<u8> {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        reader.read_nested(|reader| {
+        reader.read_prefixed(|reader| {
             let mut result = vec![0u8; reader.remaining_len()];
             reader.read(&mut result)?;
             Ok(result)
@@ -143,7 +143,7 @@ impl Decode for Vec<String> {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        reader.read_nested(|reader| {
+        reader.read_prefixed(|reader| {
             let mut entries = Self::new();
 
             while !reader.is_finished() {

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -23,13 +23,13 @@ pub trait Encode {
 
     /// Return the length of this type after encoding when prepended with a
     /// `uint32` length prefix.
-    fn encoded_len_nested(&self) -> core::result::Result<usize, Self::Error> {
+    fn encoded_len_prefixed(&self) -> core::result::Result<usize, Self::Error> {
         Ok([4, self.encoded_len()?].checked_sum()?)
     }
 
     /// Encode this value, first prepending a `uint32` length prefix
     /// set to [`Encode::encoded_len`].
-    fn encode_nested(&self, writer: &mut impl Writer) -> core::result::Result<(), Self::Error> {
+    fn encode_prefixed(&self, writer: &mut impl Writer) -> core::result::Result<(), Self::Error> {
         self.encoded_len()?.encode(writer)?;
         self.encode(writer)
     }

--- a/ssh-key/src/certificate/options_map.rs
+++ b/ssh-key/src/certificate/options_map.rs
@@ -37,7 +37,7 @@ impl Decode for OptionsMap {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        reader.read_nested(|reader| {
+        reader.read_prefixed(|reader| {
             let mut entries = Vec::<(String, String)>::new();
 
             while !reader.is_finished() {

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -41,7 +41,7 @@ impl<const SIZE: usize> Decode for EcdsaPrivateKey<SIZE> {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        reader.read_nested(|reader| {
+        reader.read_prefixed(|reader| {
             if reader.remaining_len() == SIZE.checked_add(1).ok_or(encoding::Error::Length)? {
                 // Strip leading zero
                 // TODO(tarcieri): make sure leading zero was necessary

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -219,7 +219,7 @@ impl Decode for Ed25519Keypair {
         // a serialization of `private_key[32] || public_key[32]` immediately
         // following the public key.
         let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
-        reader.read_nested(|reader| reader.read(&mut *bytes))?;
+        reader.read_prefixed(|reader| reader.read(&mut *bytes))?;
 
         let keypair = Self::from_bytes(&*bytes)?;
 

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -27,7 +27,7 @@ impl Decode for Ed25519PublicKey {
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
         let mut bytes = [0u8; Self::BYTE_SIZE];
-        reader.read_nested(|reader| reader.read(&mut bytes))?;
+        reader.read_prefixed(|reader| reader.read(&mut bytes))?;
         Ok(Self(bytes))
     }
 }

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -170,8 +170,7 @@ impl Encode for Signature {
     fn encoded_len(&self) -> Result<usize> {
         Ok([
             self.algorithm().encoded_len()?,
-            4, // signature data length prefix (uint32)
-            self.as_bytes().len(),
+            self.as_bytes().encoded_len()?,
         ]
         .checked_sum()?)
     }


### PR DESCRIPTION
Changes the names of functions which operate on length-prefixed data to "prefixed", which more clearly communicates the behavior.