### PR TITLE
ssh-key: add `SshSig::new` and `::signed_data`

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -3,16 +3,15 @@ name = "ssh-key"
 version = "0.5.0-pre.0"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
-in RFC4251 and RFC4253 as well as the OpenSSH key formats, certificates
-(including certificate validation and certificate authority support), and
-the `authorized_keys` and `known_hosts` file formats. Supports a `no_std`
-profile for embedded targets.
+in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and
+certificates (including certificate validation and certificate authority support),
+with further support for the `authorized_keys` and `known_hosts` file formats.
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RustCrypto/SSH/tree/master/ssh-key"
 categories = ["authentication", "cryptography", "encoding", "no-std", "parser-implementations"]
-keywords = ["crypto", "certificate", "key", "openssh", "ssh"]
+keywords = ["crypto", "certificate", "openssh", "ssh", "sshsig"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.60"

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -15,11 +15,11 @@ Pure Rust implementation of SSH key file format decoders/encoders as described
 in [RFC4251] and [RFC4253] as well as OpenSSH's [PROTOCOL.key] format
 specification.
 
-Additionally provides support for OpenSSH certificates as specified in
-[PROTOCOL.certkeys] including certificate validation and certificate authority
-(CA) support, as well as FIDO/U2F keys as specified in [PROTOCOL.u2f] (and
-certificates thereof), and also the `authorized_keys` and `known_hosts`
-file formats.
+Additionally provides support for SSH signatures as described in
+[PROTOCOL.sshsig], OpenSSH certificates as specified in [PROTOCOL.certkeys]
+including certificate validation and certificate authority (CA) support,
+FIDO/U2F keys as specified in [PROTOCOL.u2f] (and certificates thereof), and
+also the `authorized_keys` and `known_hosts` file formats.
 
 Supports a minimal profile which works on heapless `no_std` targets. See
 "Supported algorithms" table below for which key formats work on heapless
@@ -120,4 +120,5 @@ dual licensed as above, without any additional terms or conditions.
 [RFC4716]: https://datatracker.ietf.org/doc/html/rfc4716
 [PROTOCOL.certkeys]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD
 [PROTOCOL.key]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.key?annotate=HEAD
+[PROTOCOL.sshsig]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.sshsig?annotate=HEAD
 [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD


### PR DESCRIPTION
These static methods provide a low-level API which makes it easier to externalize signing methods more easily.