### PR TITLE
ssh-encoding: add basic tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ name = "ssh-encoding"
 version = "0.0.0"
 dependencies = [
  "base64ct",
+ "hex-literal",
  "pem-rfc7468",
  "sha2 0.10.6",
 ]

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -19,6 +19,9 @@ base64 = { package = "base64ct", version = "1.4", optional = true }
 pem = { package = "pem-rfc7468", version = "0.6", optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
+[dev-dependencies]
+hex-literal = "0.3"
+
 [features]
 alloc = ["base64?/alloc", "pem?/alloc"]
 std = ["alloc", "base64?/std", "pem?/std", "sha2?/std"]

--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -110,7 +110,7 @@ impl Decode for usize {
         if n <= MAX_SIZE {
             Ok(n)
         } else {
-            Err(Error::Length)
+            Err(Error::Overflow)
         }
     }
 }

--- a/ssh-encoding/tests/decode.rs
+++ b/ssh-encoding/tests/decode.rs
@@ -1,0 +1,74 @@
+//! Tests for the `Decode` trait.
+
+use hex_literal::hex;
+use ssh_encoding::{Decode, Error};
+
+#[test]
+fn decode_u8() {
+    let mut bytes = hex!("42").as_slice();
+    let ret = u8::decode(&mut bytes).unwrap();
+    assert_eq!(ret, 0x42u8);
+}
+
+#[test]
+fn decode_u32() {
+    let mut bytes = hex!("DEADBEEF").as_slice();
+    let ret = u32::decode(&mut bytes).unwrap();
+    assert_eq!(ret, 0xDEADBEEFu32);
+}
+
+#[test]
+fn decode_u64() {
+    let mut bytes = hex!("0000DEADBEEFCAFE").as_slice();
+    let ret = u64::decode(&mut bytes).unwrap();
+    assert_eq!(ret, 0xDEADBEEFCAFEu64);
+}
+
+#[test]
+fn decode_usize() {
+    let mut bytes = hex!("000FFFFF").as_slice();
+    let ret = usize::decode(&mut bytes).unwrap();
+    assert_eq!(ret, 0xFFFFFusize);
+}
+
+/// `usize` decoder has a sanity limit of 0xFFFFF.
+#[test]
+fn reject_oversize_usize() {
+    let mut bytes = hex!("00100000").as_slice();
+    let err = usize::decode(&mut bytes).err().unwrap();
+    assert_eq!(err, Error::Overflow);
+}
+
+#[test]
+fn decode_byte_slice() {
+    let mut bytes = hex!("000000076578616d706c65").as_slice();
+    let ret = <[u8; 7]>::decode(&mut bytes).unwrap();
+    assert_eq!(&ret, b"example");
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_byte_vec() {
+    let mut bytes = hex!("000000076578616d706c65").as_slice();
+    let ret = Vec::<u8>::decode(&mut bytes).unwrap();
+    assert_eq!(&ret, b"example");
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_string() {
+    let mut bytes = hex!("000000076578616d706c65").as_slice();
+    let ret = String::decode(&mut bytes).unwrap();
+    assert_eq!(&ret, "example");
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn decode_string_vec() {
+    let mut bytes = hex!("0000001500000003666f6f000000036261720000000362617a").as_slice();
+    let ret = Vec::<String>::decode(&mut bytes).unwrap();
+    assert_eq!(ret.len(), 3);
+    assert_eq!(ret[0], "foo");
+    assert_eq!(ret[1], "bar");
+    assert_eq!(ret[2], "baz");
+}

--- a/ssh-encoding/tests/encode.rs
+++ b/ssh-encoding/tests/encode.rs
@@ -1,0 +1,78 @@
+//! Tests for the `Encode` trait.
+
+#![cfg(feature = "alloc")]
+
+use hex_literal::hex;
+use ssh_encoding::Encode;
+
+#[test]
+fn encode_u8() {
+    let mut out = Vec::new();
+    0x42u8.encode(&mut out).unwrap();
+    assert_eq!(out, hex!("42"));
+}
+
+#[test]
+fn encode_u32() {
+    let mut out = Vec::new();
+    0xDEADBEEFu32.encode(&mut out).unwrap();
+    assert_eq!(out, hex!("DEADBEEF"));
+}
+
+#[test]
+fn encode_u64() {
+    let mut out = Vec::new();
+    0xDEADBEEFCAFEu64.encode(&mut out).unwrap();
+    assert_eq!(out, hex!("0000DEADBEEFCAFE"));
+}
+
+#[test]
+fn encode_usize() {
+    let mut out = Vec::new();
+    0xDEADBEEFusize.encode(&mut out).unwrap();
+    assert_eq!(out, hex!("DEADBEEF"));
+}
+
+#[test]
+fn encode_byte_slice() {
+    let mut out = Vec::new();
+    b"example".encode(&mut out).unwrap();
+    assert_eq!(out, hex!("000000076578616d706c65"));
+}
+
+#[test]
+fn encode_byte_vec() {
+    let mut out = Vec::new();
+    Vec::from(b"example".as_ref()).encode(&mut out).unwrap();
+    assert_eq!(out, hex!("000000076578616d706c65"));
+}
+
+#[test]
+fn encode_str() {
+    let mut out = Vec::new();
+    "example".encode(&mut out).unwrap();
+    assert_eq!(out, hex!("000000076578616d706c65"));
+}
+
+#[test]
+fn encode_string() {
+    let mut out = Vec::new();
+    String::from("example").encode(&mut out).unwrap();
+    assert_eq!(out, hex!("000000076578616d706c65"));
+}
+
+#[test]
+fn encode_string_vec() {
+    let vec = ["foo", "bar", "baz"]
+        .iter()
+        .map(|&s| s.to_owned())
+        .collect::<Vec<String>>();
+
+    let mut out = Vec::new();
+    vec.encode(&mut out).unwrap();
+
+    assert_eq!(
+        out,
+        hex!("0000001500000003666f6f000000036261720000000362617a")
+    );
+}


### PR DESCRIPTION
Adds tests for the `Decode` and `Encode` trait impls on various core Rust types.