### PR TITLE
ssh-key: unified pubkey/cert "SSH-format" encoder

### DIFF
--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -43,10 +43,7 @@ pub use crate::{
 
 #[cfg(feature = "base64")]
 pub use {
-    crate::{
-        reader::Base64Reader,
-        writer::{base64_len_approx, Base64Writer},
-    },
+    crate::{reader::Base64Reader, writer::Base64Writer},
     base64,
 };
 

--- a/ssh-encoding/src/writer.rs
+++ b/ssh-encoding/src/writer.rs
@@ -8,19 +8,6 @@ use alloc::vec::Vec;
 #[cfg(feature = "sha2")]
 use sha2::{Digest, Sha256, Sha512};
 
-/// Get the estimated length of data when encoded as Base64.
-///
-/// This is an upper bound where the actual length might be slightly shorter,
-/// and can be used to estimate the capacity of an output buffer. However, the
-/// final result may need to be sliced and should use the actual encoded length
-/// rather than this estimate.
-#[cfg(feature = "base64")]
-#[allow(clippy::integer_arithmetic)]
-pub fn base64_len_approx(input_len: usize) -> usize {
-    // TODO(tarcieri): checked arithmetic
-    (((input_len * 4) / 3) + 3) & !3
-}
-
 /// Constant-time Base64 writer implementation.
 #[cfg(feature = "base64")]
 #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -8,10 +8,10 @@ mod dsa;
 mod ecdsa;
 mod ed25519;
 mod key_data;
-mod openssh;
 #[cfg(feature = "alloc")]
 mod rsa;
 mod sk;
+mod ssh_format;
 
 pub use self::{ed25519::Ed25519PublicKey, key_data::KeyData, sk::SkEd25519};
 
@@ -21,11 +21,11 @@ pub use self::{dsa::DsaPublicKey, rsa::RsaPublicKey};
 #[cfg(feature = "ecdsa")]
 pub use self::{ecdsa::EcdsaPublicKey, sk::SkEcdsaSha2NistP256};
 
-pub(crate) use self::openssh::Encapsulation;
+pub(crate) use self::ssh_format::SshFormat;
 
 use crate::{Algorithm, Error, Fingerprint, HashAlg, Result};
 use core::str::FromStr;
-use encoding::{Base64Reader, Decode, Encode, Reader};
+use encoding::{Base64Reader, Decode, Reader};
 
 #[cfg(feature = "alloc")]
 use {
@@ -35,7 +35,7 @@ use {
         string::{String, ToString},
         vec::Vec,
     },
-    encoding::{base64_len_approx, CheckedSum},
+    encoding::Encode,
 };
 
 #[cfg(all(feature = "alloc", feature = "serde"))]
@@ -103,7 +103,7 @@ impl PublicKey {
     /// ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti foo@bar.com
     /// ```
     pub fn from_openssh(public_key: &str) -> Result<Self> {
-        let encapsulation = Encapsulation::decode(public_key.trim_end().as_bytes())?;
+        let encapsulation = SshFormat::decode(public_key.trim_end().as_bytes())?;
         let mut reader = Base64Reader::new(encapsulation.base64_data)?;
         let key_data = KeyData::decode(&mut reader)?;
 
@@ -130,9 +130,12 @@ impl PublicKey {
 
     /// Encode OpenSSH-formatted public key.
     pub fn encode_openssh<'o>(&self, out: &'o mut [u8]) -> Result<&'o str> {
-        Encapsulation::encode(out, self.algorithm().as_str(), self.comment(), |writer| {
-            self.key_data.encode(writer)
-        })
+        SshFormat::encode(
+            out,
+            self.algorithm().as_str(),
+            &self.key_data,
+            self.comment(),
+        )
     }
 
     /// Encode an OpenSSH-formatted public key, allocating a [`String`] for
@@ -140,18 +143,7 @@ impl PublicKey {
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_openssh(&self) -> Result<String> {
-        let encoded_len = [
-            2, // interstitial spaces
-            self.algorithm().as_str().len(),
-            base64_len_approx(self.key_data.encoded_len()?),
-            self.comment.len(),
-        ]
-        .checked_sum()?;
-
-        let mut buf = vec![0u8; encoded_len];
-        let actual_len = self.encode_openssh(&mut buf)?.len();
-        buf.truncate(actual_len);
-        Ok(String::from_utf8(buf)?)
+        SshFormat::encode_string(self.algorithm().as_str(), &self.key_data, self.comment())
     }
 
     /// Serialize SSH public key as raw bytes.

--- a/ssh-key/src/public/ssh_format.rs
+++ b/ssh-key/src/public/ssh_format.rs
@@ -1,9 +1,9 @@
-//! Support for OpenSSH-formatted public keys.
+//! Support for OpenSSH-formatted public keys, a.k.a. `SSH-format`.
 //!
 //! These keys have the form:
 //!
 //! ```text
-//! <algorithm id> <base64 data> <comment>
+//! <algorithm id> <base64 key data> <comment>
 //! ```
 //!
 //! ## Example
@@ -12,13 +12,16 @@
 //! ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com
 //! ```
 
-use crate::Result;
+use crate::{Error, Result};
 use core::str;
-use encoding::{Base64Writer, Error};
+use encoding::{Base64Writer, Encode};
 
-/// OpenSSH public key encapsulation parser.
+#[cfg(feature = "alloc")]
+use {alloc::string::String, encoding::CheckedSum};
+
+/// OpenSSH public key (a.k.a. `SSH-format`) decoder/encoder.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct Encapsulation<'a> {
+pub(crate) struct SshFormat<'a> {
     /// Algorithm identifier
     pub(crate) algorithm_id: &'a str,
 
@@ -30,18 +33,16 @@ pub(crate) struct Encapsulation<'a> {
     pub(crate) comment: &'a str,
 }
 
-impl<'a> Encapsulation<'a> {
+impl<'a> SshFormat<'a> {
     /// Parse the given binary data.
     pub(crate) fn decode(mut bytes: &'a [u8]) -> Result<Self> {
         let algorithm_id = decode_segment_str(&mut bytes)?;
         let base64_data = decode_segment(&mut bytes)?;
-        let comment = str::from_utf8(bytes)
-            .map_err(|_| Error::CharacterEncoding)?
-            .trim_end();
+        let comment = str::from_utf8(bytes)?.trim_end();
 
         if algorithm_id.is_empty() || base64_data.is_empty() {
             // TODO(tarcieri): better errors for these cases?
-            return Err(Error::Length.into());
+            return Err(encoding::Error::Length.into());
         }
 
         Ok(Self {
@@ -52,25 +53,26 @@ impl<'a> Encapsulation<'a> {
     }
 
     /// Encode data with OpenSSH public key encapsulation.
-    pub(crate) fn encode<'o, F>(
+    pub(crate) fn encode<'o, K>(
         out: &'o mut [u8],
         algorithm_id: &str,
+        key: &K,
         comment: &str,
-        f: F,
     ) -> Result<&'o str>
     where
-        F: FnOnce(&mut Base64Writer<'_>) -> Result<()>,
+        K: Encode<Error = Error>,
     {
         let mut offset = 0;
         encode_str(out, &mut offset, algorithm_id)?;
         encode_str(out, &mut offset, " ")?;
 
         let mut writer = Base64Writer::new(&mut out[offset..])?;
-        f(&mut writer)?;
-
+        key.encode(&mut writer)?;
         let base64_len = writer.finish()?.len();
 
-        offset = offset.checked_add(base64_len).ok_or(Error::Length)?;
+        offset = offset
+            .checked_add(base64_len)
+            .ok_or(encoding::Error::Length)?;
 
         if !comment.is_empty() {
             encode_str(out, &mut offset, " ")?;
@@ -79,6 +81,39 @@ impl<'a> Encapsulation<'a> {
 
         Ok(str::from_utf8(&out[..offset])?)
     }
+
+    /// Encode string with OpenSSH public key encapsulation.
+    #[cfg(feature = "alloc")]
+    pub(crate) fn encode_string<K>(algorithm_id: &str, key: &K, comment: &str) -> Result<String>
+    where
+        K: Encode<Error = Error>,
+    {
+        let encoded_len = [
+            2, // interstitial spaces
+            algorithm_id.len(),
+            base64_len_approx(key.encoded_len()?),
+            comment.len(),
+        ]
+        .checked_sum()?;
+
+        let mut out = vec![0u8; encoded_len];
+        let actual_len = Self::encode(&mut out, algorithm_id, key, comment)?.len();
+        out.truncate(actual_len);
+        Ok(String::from_utf8(out)?)
+    }
+}
+
+/// Get the estimated length of data when encoded as Base64.
+///
+/// This is an upper bound where the actual length might be slightly shorter,
+/// and can be used to estimate the capacity of an output buffer. However, the
+/// final result may need to be sliced and should use the actual encoded length
+/// rather than this estimate.
+#[cfg(feature = "alloc")]
+fn base64_len_approx(input_len: usize) -> usize {
+    // TODO(tarcieri): checked arithmetic
+    #[allow(clippy::integer_arithmetic)]
+    ((((input_len * 4) / 3) + 3) & !3)
 }
 
 /// Parse a segment of the public key.
@@ -92,20 +127,24 @@ fn decode_segment<'a>(bytes: &mut &'a [u8]) -> Result<&'a [u8]> {
             {
                 // Valid character; continue
                 *bytes = rest;
-                len = len.checked_add(1).ok_or(Error::Length)?;
+                len = len.checked_add(1).ok_or(encoding::Error::Length)?;
             }
             [b' ', rest @ ..] => {
                 // Encountered space; we're done
                 *bytes = rest;
-                return start.get(..len).ok_or_else(|| Error::Length.into());
+                return start
+                    .get(..len)
+                    .ok_or_else(|| encoding::Error::Length.into());
             }
             [_, ..] => {
                 // Invalid character
-                return Err(Error::CharacterEncoding.into());
+                return Err(encoding::Error::CharacterEncoding.into());
             }
             [] => {
                 // End of input, could be truncated or could be no comment
-                return start.get(..len).ok_or_else(|| Error::Length.into());
+                return start
+                    .get(..len)
+                    .ok_or_else(|| encoding::Error::Length.into());
             }
         }
     }
@@ -113,32 +152,38 @@ fn decode_segment<'a>(bytes: &mut &'a [u8]) -> Result<&'a [u8]> {
 
 /// Parse a segment of the public key as a `&str`.
 fn decode_segment_str<'a>(bytes: &mut &'a [u8]) -> Result<&'a str> {
-    str::from_utf8(decode_segment(bytes)?).map_err(|_| Error::CharacterEncoding.into())
+    str::from_utf8(decode_segment(bytes)?).map_err(|_| encoding::Error::CharacterEncoding.into())
 }
 
 /// Encode a segment of the public key.
 fn encode_str(out: &mut [u8], offset: &mut usize, s: &str) -> Result<()> {
     let bytes = s.as_bytes();
 
-    if out.len() < offset.checked_add(bytes.len()).ok_or(Error::Length)? {
-        return Err(Error::Length.into());
+    if out.len()
+        < offset
+            .checked_add(bytes.len())
+            .ok_or(encoding::Error::Length)?
+    {
+        return Err(encoding::Error::Length.into());
     }
 
     out[*offset..][..bytes.len()].copy_from_slice(bytes);
-    *offset = offset.checked_add(bytes.len()).ok_or(Error::Length)?;
+    *offset = offset
+        .checked_add(bytes.len())
+        .ok_or(encoding::Error::Length)?;
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Encapsulation;
+    use super::SshFormat;
 
     const EXAMPLE_KEY: &str = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com";
 
     #[test]
     fn decode() {
-        let encapsulation = Encapsulation::decode(EXAMPLE_KEY.as_bytes()).unwrap();
+        let encapsulation = SshFormat::decode(EXAMPLE_KEY.as_bytes()).unwrap();
         assert_eq!(encapsulation.algorithm_id, "ssh-ed25519");
         assert_eq!(
             encapsulation.base64_data,


### PR DESCRIPTION
Unifies the logic for encoding public keys and certificates in the algorithm/key/comment "SSH-format", e.g.:

    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com

This removes the need for `base64_len_approx` to be located in the `ssh-encoding` crate.