### PR TITLE
ssh-encoding: unify PEM encoding in `EncodePem` trait

### DIFF
--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -49,12 +49,10 @@ pub use {
 
 #[cfg(feature = "pem")]
 pub use {
-    crate::decode::DecodePem,
+    crate::{decode::DecodePem, encode::EncodePem},
     pem::{self, LineEnding},
 };
 
-#[cfg(all(feature = "alloc", feature = "pem"))]
-pub use crate::encode::EncodePem;
-
 /// Line width used by the PEM encoding of OpenSSH documents.
-pub const PEM_LINE_WIDTH: usize = 70;
+#[cfg(feature = "pem")]
+const PEM_LINE_WIDTH: usize = 70;

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -139,14 +139,13 @@ pub use self::sk::SkEcdsaSha2NistP256;
 use crate::{public, Algorithm, Cipher, Error, Fingerprint, HashAlg, Kdf, PublicKey, Result};
 use core::str;
 use encoding::{
-    pem::{self, LineEnding, PemLabel},
-    CheckedSum, Decode, DecodePem, Encode, Reader, Writer, PEM_LINE_WIDTH,
+    pem::{LineEnding, PemLabel},
+    CheckedSum, Decode, DecodePem, Encode, EncodePem, Reader, Writer,
 };
 
 #[cfg(feature = "alloc")]
 use {
     alloc::{string::String, vec::Vec},
-    encoding::EncodePem,
     zeroize::Zeroizing,
 };
 
@@ -243,12 +242,7 @@ impl PrivateKey {
         line_ending: LineEnding,
         out: &'o mut [u8],
     ) -> Result<&'o str> {
-        let mut writer =
-            pem::Encoder::new_wrapped(Self::PEM_LABEL, PEM_LINE_WIDTH, line_ending, out)?;
-
-        self.encode(&mut writer)?;
-        let encoded_len = writer.finish()?;
-        Ok(str::from_utf8(&out[..encoded_len])?)
+        self.encode_pem(line_ending, out)
     }
 
     /// Encode an OpenSSH-formatted PEM private key, allocating a
@@ -256,7 +250,7 @@ impl PrivateKey {
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_openssh(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
-        self.encode_pem(line_ending).map(Zeroizing::new)
+        self.encode_pem_string(line_ending).map(Zeroizing::new)
     }
 
     /// Serialize SSH private key as raw bytes.

--- a/ssh-key/src/sshsig.rs
+++ b/ssh-key/src/sshsig.rs
@@ -85,7 +85,7 @@ impl SshSig {
     /// -----BEGIN SSH SIGNATURE-----
     /// ```
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<String> {
-        self.encode_pem(line_ending)
+        self.encode_pem_string(line_ending)
     }
 
     /// Sign the given message with the provided signing key.


### PR DESCRIPTION
This commit adds a "heapless" mode for `EncodePem` which writes the encoded output to a provided buffer.

The old `EncodePem::encode_pem` method is renamed to `encode_pem_string` which is composed in terms of the new `::encode_pem` method.

This replaces the previous logic for doing this in the `ssh-key` crate.