### PR TITLE
ssh-key v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes",
  "bcrypt-pbkdf",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2022-10-25)
+### Changed
+- README.md improvements ([#41])
+
+[#41]: https://github.com/RustCrypto/SSH/pull/41
+
 ## 0.5.0 (2022-10-25)
 ### Added
 - `p384` feature ([#21])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.5.0"
+version = "0.5.1"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and


### PR DESCRIPTION
### Changed
- README.md improvements ([#41])

[#41]: https://github.com/RustCrypto/SSH/pull/41