### PR TITLE
.github: perform `--release` build in CI

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -46,7 +46,7 @@ jobs:
           profile: minimal
           override: true
       - run: ${{ matrix.deps }}
-      - run: cargo build --target ${{ matrix.target }} --all-features
+      - run: cargo build --target ${{ matrix.target }} --release --all-features
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master


### PR DESCRIPTION
Possible workaround for the OOM issue