### PR TITLE
ssh-key: bump `signature` to v2.0.0-pre.3

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -48,10 +48,11 @@ jobs:
       - run: ${{ matrix.deps }}
       - run: cargo build --target ${{ matrix.target }} --release --all-features
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+# TODO(tarcieri): re-enable when `ed25519-dalek` v2.0 is released
+#  minimal-versions:
+#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+#    with:
+#        working-directory: ${{ github.workflow }}
 
   no_std:
     runs-on: ubuntu-latest
@@ -89,4 +90,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset
+      - run: cargo hack test --feature-powerset --exclude-features default,std
+      - run: cargo test
+      - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "3806a8db60cf56efee531616a34a6aaa9a114d6da2add861b0fa4a188881b2c7"
 dependencies = [
  "blowfish",
  "pbkdf2",
- "sha2 0.10.6",
+ "sha2",
 ]
 
 [[package]]
@@ -47,15 +47,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -120,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -146,13 +137,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "1a27a3e18f01e2f43cbd254758a5624f8c46763ff8071b2601b06b1f6c82a143"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "digest",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -164,26 +158,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
-dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -191,27 +175,25 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.4.2"
+version = "0.5.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea215d527d679032a8fd66de127d34957761717e9719ee4f0e6d5ca01aea2840"
+checksum = "63d69de3a13067778104ee09c27dd783fde784c8ed3989e33ac75cc543c9df04"
 dependencies = [
- "digest 0.10.5",
+ "digest",
  "num-bigint-dig",
  "num-traits",
- "opaque-debug",
  "pkcs8",
- "rand 0.8.5",
  "rfc6979",
- "sha2 0.10.6",
+ "sha2",
  "signature",
  "zeroize",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.15.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "deb984c19733374d04faa1143d4a952d9621564760561d5272bffcf45723268e"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -221,24 +203,24 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "2.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "f623b71a767bb00fdeb8e0137e69cf2b148616db4ba016c121b36578e783c7f1"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek?branch=release/2.0#616d55c36c59e82172ff24af13c9a72f3194052f"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -251,11 +233,11 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -276,9 +258,15 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
 
 [[package]]
 name = "generic-array"
@@ -292,24 +280,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -319,7 +296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -335,7 +312,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest",
 ]
 
 [[package]]
@@ -373,24 +350,29 @@ checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
- "libm",
+ "libm 0.2.5",
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
- "serde",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -423,35 +405,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
+ "libm 0.2.5",
 ]
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.12.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "fc1a3b210d4c53f946086dd6d2df73c033c70a5b616871edb2b6543ae3963450"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.11.2"
+version = "0.12.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+checksum = "cfe4780297b9a043294f9abb9dfd9f009fee16597c18fe10e34f09b2e9874694"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -460,7 +448,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.5",
+ "digest",
 ]
 
 [[package]]
@@ -494,40 +482,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.46"
+name = "primeorder"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "28e9faa13b820095bbf5b1ba3f979430a44a60403aa10c4ae419c47e39408576"
 dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -537,18 +509,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -558,16 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -576,16 +529,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -619,21 +563,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.7.2"
+version = "0.8.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
+checksum = "0aaaa8c2e69136da455f024082d0ab89e8920bf5512e05775420e2e1577df02f"
 dependencies = [
  "byteorder",
- "digest 0.10.5",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "signature",
- "smallvec",
  "subtle",
  "zeroize",
 ]
@@ -666,20 +609,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -690,17 +620,17 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "72c5ea30954aaba8f04263dd4d766a33d4838ae5535fccc81341b147604e7526"
 dependencies = [
- "digest 0.10.5",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -732,12 +662,12 @@ dependencies = [
  "base64ct",
  "hex-literal",
  "pem-rfc7468",
- "sha2 0.10.6",
+ "sha2",
 ]
 
 [[package]]
 name = "ssh-key"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "aes",
  "bcrypt-pbkdf",
@@ -748,13 +678,13 @@ dependencies = [
  "num-bigint-dig",
  "p256",
  "p384",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
  "rsa",
  "sec1",
  "serde",
  "sha1",
- "sha2 0.10.6",
+ "sha2",
  "signature",
  "ssh-encoding",
  "subtle",
@@ -767,29 +697,6 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "syn"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
 
 [[package]]
 name = "tempfile"
@@ -812,28 +719,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -868,18 +757,3 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io.ed25519-dalek]
+git = "https://github.com/dalek-cryptography/ed25519-dalek"
+branch = "release/2.0"

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and
@@ -19,25 +19,24 @@ rust-version = "1.60"
 [dependencies]
 encoding = { package = "ssh-encoding", version = "0.1", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
 sha2 = { version = "0.10.6", default-features = false }
+signature = { version = "=2.0.0-pre.3", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 aes = { version = "0.8", optional = true, default-features = false }
 ctr = { version = "0.9", optional = true, default-features = false }
 bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
-bigint = { package = "num-bigint-dig", version = "0.8", optional = true }
-dsa = { version = "0.4.2", optional = true, default-features = false }
-ed25519-dalek = { version = "1.0.1", optional = true, default-features = false, features = ["u64_backend"] }
-p256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa"] }
+bigint = { package = "num-bigint-dig", version = "0.8", optional = true, default-features = false }
+dsa = { version = "=0.5.0-pre.1", optional = true, default-features = false }
+ed25519-dalek = { version = "1.0.1", optional = true, default-features = false }
+p256 = { version = "=0.12.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "=0.12.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6", optional = true, default-features = false }
-rsa = { version = "0.7", optional = true }
+rsa = { version = "0.8.0-pre.0", optional = true, default-features = false }
 sec1 = { version = "0.3", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha1 = { version = "0.10", optional = true, default-features = false }
-signature = { version = "1.6.4", optional = true, default-features = false }
-subtle = { version = "2", optional = true, default-features = false }
-
 [dev-dependencies]
 hex-literal = "0.3.4"
 rand_chacha = "0.3"
@@ -47,7 +46,7 @@ tempfile = "3"
 default = ["ecdsa", "rand_core", "std"]
 alloc = [
     "encoding/alloc",
-    "signature/hazmat-preview",
+    "signature/alloc",
     "zeroize/alloc"
 ]
 std = [
@@ -58,15 +57,15 @@ std = [
     "p384?/std",
     "rsa?/std",
     "sec1?/std",
-    "signature?/std"
+    "signature/std"
 ]
 
-dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "signature/rand-preview"]
+dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand-preview"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [ "alloc", "dep:aes", "dep:bcrypt-pbkdf", "dep:ctr", "rand_core"]
 getrandom = ["rand_core/getrandom"]
-rsa = ["dep:bigint", "dep:rsa", "sha2/oid"]
+rsa = ["dep:bigint", "dep:rsa", "alloc", "rand_core", "sha2/oid"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -131,6 +131,18 @@ impl From<encoding::pem::Error> for Error {
     }
 }
 
+impl From<signature::Error> for Error {
+    fn from(_: signature::Error) -> Error {
+        Error::Crypto
+    }
+}
+
+impl From<Error> for signature::Error {
+    fn from(_: Error) -> signature::Error {
+        signature::Error::new()
+    }
+}
+
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<alloc::string::FromUtf8Error> for Error {
@@ -152,22 +164,6 @@ impl From<sec1::Error> for Error {
 impl From<rsa::errors::Error> for Error {
     fn from(_: rsa::errors::Error) -> Error {
         Error::Crypto
-    }
-}
-
-#[cfg(feature = "signature")]
-#[cfg_attr(docsrs, doc(cfg(feature = "signature")))]
-impl From<signature::Error> for Error {
-    fn from(_: signature::Error) -> Error {
-        Error::Crypto
-    }
-}
-
-#[cfg(feature = "signature")]
-#[cfg_attr(docsrs, doc(cfg(feature = "signature")))]
-impl From<Error> for signature::Error {
-    fn from(_: Error) -> signature::Error {
-        signature::Error::new()
     }
 }
 

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(
     clippy::integer_arithmetic,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
     clippy::unwrap_used,

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -79,36 +79,36 @@ impl fmt::UpperHex for Ed25519PublicKey {
 
 #[cfg(feature = "ed25519")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
-impl TryFrom<Ed25519PublicKey> for ed25519_dalek::PublicKey {
+impl TryFrom<Ed25519PublicKey> for ed25519_dalek::VerifyingKey {
     type Error = Error;
 
-    fn try_from(key: Ed25519PublicKey) -> Result<ed25519_dalek::PublicKey> {
-        ed25519_dalek::PublicKey::try_from(&key)
+    fn try_from(key: Ed25519PublicKey) -> Result<ed25519_dalek::VerifyingKey> {
+        ed25519_dalek::VerifyingKey::try_from(&key)
     }
 }
 
 #[cfg(feature = "ed25519")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
-impl TryFrom<&Ed25519PublicKey> for ed25519_dalek::PublicKey {
+impl TryFrom<&Ed25519PublicKey> for ed25519_dalek::VerifyingKey {
     type Error = Error;
 
-    fn try_from(key: &Ed25519PublicKey) -> Result<ed25519_dalek::PublicKey> {
-        ed25519_dalek::PublicKey::from_bytes(key.as_ref()).map_err(|_| Error::Crypto)
+    fn try_from(key: &Ed25519PublicKey) -> Result<ed25519_dalek::VerifyingKey> {
+        ed25519_dalek::VerifyingKey::from_bytes(key.as_ref()).map_err(|_| Error::Crypto)
     }
 }
 
 #[cfg(feature = "ed25519")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
-impl From<ed25519_dalek::PublicKey> for Ed25519PublicKey {
-    fn from(key: ed25519_dalek::PublicKey) -> Ed25519PublicKey {
+impl From<ed25519_dalek::VerifyingKey> for Ed25519PublicKey {
+    fn from(key: ed25519_dalek::VerifyingKey) -> Ed25519PublicKey {
         Ed25519PublicKey::from(&key)
     }
 }
 
 #[cfg(feature = "ed25519")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
-impl From<&ed25519_dalek::PublicKey> for Ed25519PublicKey {
-    fn from(key: &ed25519_dalek::PublicKey) -> Ed25519PublicKey {
+impl From<&ed25519_dalek::VerifyingKey> for Ed25519PublicKey {
+    fn from(key: &ed25519_dalek::VerifyingKey) -> Ed25519PublicKey {
         Ed25519PublicKey(key.to_bytes())
     }
 }

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -32,7 +32,7 @@ const ED25519_CERT_WITH_P256_CA_EXAMPLE: &str =
     include_str!("examples/id_ed25519-cert-with-p256-ca.pub");
 
 /// Ed25519 OpenSSH Certificate with RSA certificate authority
-#[cfg(feature = "p256")]
+#[cfg(feature = "rsa")]
 const ED25519_CERT_WITH_RSA_CA_EXAMPLE: &str =
     include_str!("examples/id_ed25519-cert-with-rsa-ca.pub");
 

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -6,7 +6,7 @@ use hex_literal::hex;
 use ssh_key::{Algorithm, Cipher, Kdf, KdfAlg, PrivateKey};
 
 /// Unencrypted Ed25519 OpenSSH-formatted private key.
-#[cfg(all(feature = "encryption", feature = "subtle"))]
+#[cfg(all(feature = "encryption"))]
 const OPENSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
 
 /// Encrypted Ed25519 OpenSSH-formatted private key.
@@ -15,7 +15,7 @@ const OPENSSH_ED25519_EXAMPLE: &str = include_str!("examples/id_ed25519");
 const OPENSSH_ED25519_ENC_EXAMPLE: &str = include_str!("examples/id_ed25519.enc");
 
 /// Bad password; don't actually use outside tests!
-#[cfg(all(feature = "encryption", feature = "subtle"))]
+#[cfg(all(feature = "encryption"))]
 const PASSWORD: &[u8] = b"hunter42";
 
 #[test]
@@ -39,7 +39,7 @@ fn decode_ed25519_enc_openssh() {
     );
 }
 
-#[cfg(all(feature = "encryption", feature = "subtle"))]
+#[cfg(all(feature = "encryption"))]
 #[test]
 fn decrypt_ed25519_enc_openssh() {
     let key_enc = PrivateKey::from_openssh(OPENSSH_ED25519_ENC_EXAMPLE).unwrap();
@@ -59,7 +59,7 @@ fn encode_ed25519_enc_openssh() {
     );
 }
 
-#[cfg(all(feature = "encryption", feature = "getrandom", feature = "subtle"))]
+#[cfg(all(feature = "encryption", feature = "getrandom"))]
 #[test]
 fn encrypt_ed25519_openssh() {
     use rand_core::OsRng;

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -6,10 +6,10 @@ use ssh_key::{Algorithm, Cipher, KdfAlg, PrivateKey};
 #[cfg(feature = "ecdsa")]
 use ssh_key::EcdsaCurve;
 
-#[cfg(all(feature = "alloc", feature = "subtle"))]
+#[cfg(all(feature = "alloc"))]
 use ssh_key::LineEnding;
 
-#[cfg(all(feature = "std", feature = "subtle"))]
+#[cfg(all(feature = "std"))]
 use {
     ssh_key::PublicKey,
     std::{io, process},
@@ -367,50 +367,50 @@ fn decode_rsa_4096_openssh() {
     assert_eq!("user@example.com", key.comment());
 }
 
-#[cfg(all(feature = "alloc", feature = "subtle"))]
+#[cfg(all(feature = "alloc"))]
 #[test]
 fn encode_dsa_openssh() {
     encoding_test(OPENSSH_DSA_EXAMPLE)
 }
 
-#[cfg(all(feature = "alloc", feature = "ecdsa", feature = "subtle"))]
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
 #[test]
 fn encode_ecdsa_p256_openssh() {
     encoding_test(OPENSSH_ECDSA_P256_EXAMPLE)
 }
 
-#[cfg(all(feature = "alloc", feature = "ecdsa", feature = "subtle"))]
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
 #[test]
 fn encode_ecdsa_p384_openssh() {
     encoding_test(OPENSSH_ECDSA_P384_EXAMPLE)
 }
 
-#[cfg(all(feature = "alloc", feature = "ecdsa", feature = "subtle"))]
+#[cfg(all(feature = "alloc", feature = "ecdsa"))]
 #[test]
 fn encode_ecdsa_p521_openssh() {
     encoding_test(OPENSSH_ECDSA_P521_EXAMPLE)
 }
 
-#[cfg(all(feature = "alloc", feature = "subtle"))]
+#[cfg(all(feature = "alloc"))]
 #[test]
 fn encode_ed25519_openssh() {
     encoding_test(OPENSSH_ED25519_EXAMPLE)
 }
 
-#[cfg(all(feature = "alloc", feature = "subtle"))]
+#[cfg(all(feature = "alloc"))]
 #[test]
 fn encode_rsa_3072_openssh() {
     encoding_test(OPENSSH_RSA_3072_EXAMPLE)
 }
 
-#[cfg(all(feature = "alloc", feature = "subtle"))]
+#[cfg(all(feature = "alloc"))]
 #[test]
 fn encode_rsa_4096_openssh() {
     encoding_test(OPENSSH_RSA_4096_EXAMPLE)
 }
 
 /// Common behavior of all encoding tests
-#[cfg(all(feature = "alloc", feature = "subtle"))]
+#[cfg(all(feature = "alloc"))]
 fn encoding_test(private_key: &str) {
     let key = PrivateKey::from_openssh(private_key).unwrap();
 
@@ -424,7 +424,7 @@ fn encoding_test(private_key: &str) {
 }
 
 /// Parse PEM encoded using `PrivateKey::to_openssh` using the `ssh-keygen` utility.
-#[cfg(all(feature = "std", feature = "subtle"))]
+#[cfg(all(feature = "std"))]
 fn encoding_integration_test(private_key: PrivateKey) {
     let dir = tempfile::tempdir().unwrap();
     let mut path = dir.path().to_owned();

--- a/ssh-key/tests/sshsig.rs
+++ b/ssh-key/tests/sshsig.rs
@@ -5,8 +5,11 @@
 use hex_literal::hex;
 use ssh_key::{Algorithm, HashAlg, LineEnding, PublicKey, SshSig};
 
+#[cfg(any(feature = "dsa", feature = "ed25519", feature = "rsa"))]
+use ssh_key::PrivateKey;
+
 #[cfg(feature = "ed25519")]
-use ssh_key::{Error, PrivateKey};
+use ssh_key::Error;
 
 /// DSA OpenSSH-formatted private key.
 #[cfg(feature = "dsa")]
@@ -62,7 +65,7 @@ const RSA_PRIVATE_KEY: &str = include_str!("examples/id_rsa_3072");
 const RSA_PUBLIC_KEY: &str = include_str!("examples/id_rsa_3072.pub");
 
 /// Example message to be signed/verified.
-#[cfg(feature = "ed25519")]
+#[allow(dead_code)]
 const MSG_EXAMPLE: &[u8] = b"testing";
 
 /// Example domain/namespace used for the message.


### PR DESCRIPTION
Also bumps crate version to v0.6.0-pre (unreleased) as this is a breaking change to the public API.