### PR TITLE
Bump `signature` crate dependency to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64ct"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bcrypt-pbkdf"
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "cpufeatures"
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -137,25 +137,23 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27a3e18f01e2f43cbd254758a5624f8c46763ff8071b2601b06b1f6c82a143"
+version = "4.0.0-pre.5"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek#fedb1450dec58d86851ba67f2363ccde4e45ae16"
 dependencies = [
  "cfg-if",
  "digest",
  "fiat-crypto",
  "packed_simd_2",
  "platforms",
- "rand_core",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -175,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.5.0-pre.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d69de3a13067778104ee09c27dd783fde784c8ed3989e33ac75cc543c9df04"
+checksum = "664d19f8b4e0481c55d76fa6ed402a7a9a8821857ba37f2ec1fdb43af6f19cf7"
 dependencies = [
  "digest",
  "num-bigint-dig",
@@ -191,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.15.0-pre.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb984c19733374d04faa1143d4a952d9621564760561d5272bffcf45723268e"
+checksum = "82508ce57bd2b245e9914411800f87fd8fc8288f501bb26919cb9b2ee964028f"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -203,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.0.0-pre.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f623b71a767bb00fdeb8e0137e69cf2b148616db4ba016c121b36578e783c7f1"
+checksum = "a3af5919f6d605315213c36abdd435562224665993b274912dee0d9a0e2fed8a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -214,11 +212,10 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
-source = "git+https://github.com/dalek-cryptography/ed25519-dalek?branch=release/2.0#616d55c36c59e82172ff24af13c9a72f3194052f"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek?branch=release/2.0#6d9bbd323edfce04f600427571e90afd86f52939"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
  "serde",
  "sha2",
  "zeroize",
@@ -254,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core",
  "subtle",
@@ -280,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -291,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
  "rand_core",
@@ -344,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
@@ -356,9 +353,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "num-bigint-dig"
@@ -368,7 +365,7 @@ checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
- "libm 0.2.5",
+ "libm 0.2.6",
  "num-integer",
  "num-iter",
  "num-traits",
@@ -405,14 +402,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm 0.2.5",
+ "libm 0.2.6",
 ]
 
 [[package]]
 name = "p256"
-version = "0.12.0-pre.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1a3b210d4c53f946086dd6d2df73c033c70a5b616871edb2b6543ae3963450"
+checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -422,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.12.0-pre.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4780297b9a043294f9abb9dfd9f009fee16597c18fe10e34f09b2e9874694"
+checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -462,12 +459,13 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3a81571d9455414f4d59ce2830bc9d2654e2efc5460fd67b0e0a6a36b6753a"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
  "der",
  "pkcs8",
+ "spki",
  "zeroize",
 ]
 
@@ -489,15 +487,15 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.0.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e9faa13b820095bbf5b1ba3f979430a44a60403aa10c4ae419c47e39408576"
+checksum = "49b7e10b3a364b1c813238b1c9a749336cbe51fd4265cd99f57cf29302c90af7"
 dependencies = [
  "elliptic-curve",
 ]
@@ -508,7 +506,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
@@ -552,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -563,9 +560,8 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.8.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aaaa8c2e69136da455f024082d0ab89e8920bf5512e05775420e2e1577df02f"
+version = "0.8.0"
+source = "git+https://github.com/rustcrypto/rsa?branch=v0.8.0#0423cf89a0eea59f3ec55b0a7e5bf2231f6db9cf"
 dependencies = [
  "byteorder",
  "digest",
@@ -625,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0-pre.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c5ea30954aaba8f04263dd4d766a33d4838ae5535fccc81341b147604e7526"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
  "rand_core",
@@ -714,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 [profile.dev]
 opt-level = 2
 
-[patch.crates-io.ed25519-dalek]
-git = "https://github.com/dalek-cryptography/ed25519-dalek"
-branch = "release/2.0"
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek" }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", branch = "release/2.0" }
+rsa = { git = "https://github.com/rustcrypto/rsa", branch = "v0.8.0" }

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.60"
 [dependencies]
 encoding = { package = "ssh-encoding", version = "0.1", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
 sha2 = { version = "0.10.6", default-features = false }
-signature = { version = "=2.0.0-pre.3", default-features = false }
+signature = { version = "2", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
@@ -28,15 +28,16 @@ aes = { version = "0.8", optional = true, default-features = false }
 ctr = { version = "0.9", optional = true, default-features = false }
 bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
 bigint = { package = "num-bigint-dig", version = "0.8", optional = true, default-features = false }
-dsa = { version = "=0.5.0-pre.1", optional = true, default-features = false }
+dsa = { version = "0.5", optional = true, default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true, default-features = false }
-p256 = { version = "=0.12.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "=0.12.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6", optional = true, default-features = false }
-rsa = { version = "0.8.0-pre.0", optional = true, default-features = false }
+rsa = { version = "0.8", optional = true, default-features = false }
 sec1 = { version = "0.3", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha1 = { version = "0.10", optional = true, default-features = false }
+
 [dev-dependencies]
 hex-literal = "0.3.4"
 rand_chacha = "0.3"
@@ -60,7 +61,7 @@ std = [
     "signature/std"
 ]
 
-dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand-preview"]
+dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand_core"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [ "alloc", "dep:aes", "dep:bcrypt-pbkdf", "dep:ctr", "rand_core"]


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/traits/pull/1211

This also bumps the following crates:

- `dsa` v0.5
- `ed25519-dalek` "2.0" (via git)
- `p256` v0.12
- `p384` v0.12
- `rsa` v0.8 (via git)