### PR TITLE
ssh-key: fix error type for `Signature` bytes conversion

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -222,11 +222,10 @@ impl SignatureEncoding for Signature {
 
 /// Decode [`Signature`] from an [`Algorithm`]-prefixed OpenSSH-encoded bytestring.
 impl TryFrom<&[u8]> for Signature {
-    // TODO(tarcieri): use `ssh_key::Error` instead of `signature::Error`
-    type Error = signature::Error;
+    type Error = Error;
 
-    fn try_from(mut bytes: &[u8]) -> signature::Result<Self> {
-        Ok(Self::decode(&mut bytes)?)
+    fn try_from(mut bytes: &[u8]) -> Result<Self> {
+        Self::decode(&mut bytes)
     }
 }
 


### PR DESCRIPTION
Addresses a TODO about changing the error type for `TryFrom<&[u8]>` to `ssh_key::Error`, now that the `signature` crate's bounds have been changed in order to make that possible.