### PR TITLE
ssh-key: bump elliptic curve and password hash deps; MSRV 1.65

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0
+          toolchain: 1.67.0
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
@@ -33,9 +33,9 @@ checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3806a8db60cf56efee531616a34a6aaa9a114d6da2add861b0fa4a188881b2c7"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
 dependencies = [
  "blowfish",
  "pbkdf2",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cpufeatures"
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "071c0f5945634bc9ba7a452f492377dd6b1993665ddb58f28704119b32f07a9a"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -161,6 +161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc302fd9b18d66834a6f092d10ea85489c0ca8ad6b7304092135fab171d853cd"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,14 +184,14 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d19f8b4e0481c55d76fa6ed402a7a9a8821857ba37f2ec1fdb43af6f19cf7"
+checksum = "8740edd2ee6308c3dc0a424117c0fc83248330f58d875ba83e412022f27753c9"
 dependencies = [
  "digest",
  "num-bigint-dig",
  "num-traits",
- "pkcs8",
+ "pkcs8 0.10.1",
  "rfc6979",
  "sha2",
  "signature",
@@ -190,11 +200,11 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82508ce57bd2b245e9914411800f87fd8fc8288f501bb26919cb9b2ee964028f"
+checksum = "cbcfcadd7eade8d8f960aa721e9731a50081694d3118c80eba744cbf68c7e5db"
 dependencies = [
- "der",
+ "der 0.7.0",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -206,7 +216,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf420a7ec85d98495b0c34aa4a58ca117f982ffbece111aeb545160148d7010"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.9.0",
  "signature",
 ]
 
@@ -225,17 +235,17 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b984fcbd8df0166b077ec083cbfe076fdffb6e2de92d966794fd060794b620d7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest",
  "ff",
  "generic-array",
  "group",
+ "pkcs8 0.10.1",
  "rand_core",
  "sec1",
  "subtle",
@@ -253,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -275,6 +285,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -290,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core",
@@ -409,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -421,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -443,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
 dependencies = [
  "digest",
 ]
@@ -465,9 +476,9 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
  "zeroize",
 ]
 
@@ -477,8 +488,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der 0.7.0",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -495,9 +516,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b7e10b3a364b1c813238b1c9a749336cbe51fd4265cd99f57cf29302c90af7"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
 dependencies = [
  "elliptic-curve",
 ]
@@ -551,13 +572,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -573,7 +593,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core",
  "signature",
  "subtle",
@@ -582,14 +602,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.0",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -651,7 +671,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.0",
 ]
 
 [[package]]

--- a/ssh-encoding/src/error.rs
+++ b/ssh-encoding/src/error.rs
@@ -38,16 +38,15 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             #[cfg(feature = "base64")]
-            Error::Base64(err) => write!(f, "Base64 encoding error: {}", err),
+            Error::Base64(err) => write!(f, "Base64 encoding error: {err}"),
             Error::CharacterEncoding => write!(f, "character encoding invalid"),
             Error::Length => write!(f, "length invalid"),
             Error::Overflow => write!(f, "internal overflow error"),
             #[cfg(feature = "pem")]
-            Error::Pem(err) => write!(f, "{}", err),
+            Error::Pem(err) => write!(f, "{err}"),
             Error::TrailingData { remaining } => write!(
                 f,
-                "unexpected trailing data at end of message ({} bytes)",
-                remaining
+                "unexpected trailing data at end of message ({remaining} bytes)",
             ),
         }
     }
@@ -99,4 +98,14 @@ impl From<pem::Error> for Error {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            #[cfg(feature = "base64")]
+            Self::Base64(err) => Some(err),
+            #[cfg(feature = "pem")]
+            Self::Pem(err) => Some(err),
+            _ => None,
+        }
+    }
+}

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["authentication", "cryptography", "encoding", "no-std", "parser-im
 keywords = ["crypto", "certificate", "openssh", "ssh", "sshsig"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [dependencies]
 encoding = { package = "ssh-encoding", version = "0.1", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
@@ -26,15 +26,15 @@ zeroize = { version = "1", default-features = false }
 # optional dependencies
 aes = { version = "0.8", optional = true, default-features = false }
 ctr = { version = "0.9", optional = true, default-features = false }
-bcrypt-pbkdf = { version = "0.9", optional = true, default-features = false }
+bcrypt-pbkdf = { version = "0.10", optional = true, default-features = false, features = ["alloc"] }
 bigint = { package = "num-bigint-dig", version = "0.8", optional = true, default-features = false }
-dsa = { version = "0.5", optional = true, default-features = false }
+dsa = { version = "0.6", optional = true, default-features = false }
 ed25519-dalek = { version = "=2.0.0-pre.0", optional = true, default-features = false }
-p256 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa"] }
-rand_core = { version = "0.6", optional = true, default-features = false }
+p256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
+rand_core = { version = "0.6.4", optional = true, default-features = false }
 rsa = { version = "0.8", optional = true, default-features = false }
-sec1 = { version = "0.3", optional = true, default-features = false, features = ["point"] }
+sec1 = { version = "0.7", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha1 = { version = "0.10", optional = true, default-features = false }
 

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -79,7 +79,7 @@ functionality for a particular SSH key algorithm.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -106,7 +106,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ssh-key/badge.svg
 [docs-link]: https://docs.rs/ssh-key/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-key.yml/badge.svg

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -208,7 +208,7 @@ impl Certificate {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_file(path: &Path) -> Result<Self> {
         let input = fs::read_to_string(path)?;
-        Self::from_openssh(&*input)
+        Self::from_openssh(&input)
     }
 
     /// Write OpenSSH certificate to a file.

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -76,14 +76,14 @@ impl fmt::Display for Error {
             Error::Algorithm => write!(f, "unknown or unsupported algorithm"),
             #[cfg(feature = "alloc")]
             Error::CertificateFieldInvalid(field) => {
-                write!(f, "certificate field invalid: {}", field)
+                write!(f, "certificate field invalid: {field}")
             }
             Error::CertificateValidation => write!(f, "certificate validation failed"),
             Error::Crypto => write!(f, "cryptographic error"),
             Error::Decrypted => write!(f, "private key is already decrypted"),
             #[cfg(feature = "ecdsa")]
-            Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {}", err),
-            Error::Encoding(err) => write!(f, "{}", err),
+            Error::Ecdsa(err) => write!(f, "ECDSA encoding error: {err}"),
+            Error::Encoding(err) => write!(f, "{err}"),
             Error::Encrypted => write!(f, "private key is encrypted"),
             Error::FormatEncoding => write!(f, "format encoding error"),
             #[cfg(feature = "std")]
@@ -93,10 +93,9 @@ impl fmt::Display for Error {
             Error::Time => write!(f, "invalid time"),
             Error::TrailingData { remaining } => write!(
                 f,
-                "unexpected trailing data at end of message ({} bytes)",
-                remaining
+                "unexpected trailing data at end of message ({remaining} bytes)",
             ),
-            Error::Version { number: version } => write!(f, "version unsupported: {}", version),
+            Error::Version { number: version } => write!(f, "version unsupported: {version}"),
         }
     }
 }
@@ -185,4 +184,13 @@ impl From<std::time::SystemTimeError> for Error {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            #[cfg(feature = "ecdsa")]
+            Self::Ecdsa(err) => Some(err),
+            Self::Encoding(err) => Some(err),
+            _ => None,
+        }
+    }
+}

--- a/ssh-key/src/fingerprint.rs
+++ b/ssh-key/src/fingerprint.rs
@@ -131,7 +131,7 @@ impl Display for Fingerprint {
         // Buffer size is the largest digest size of of any supported hash function
         let mut buf = [0u8; Self::SHA512_BASE64_SIZE];
         let base64 = Base64Unpadded::encode(self.as_bytes(), &mut buf).map_err(|_| fmt::Error)?;
-        write!(f, "{}:{}", algorithm, base64)
+        write!(f, "{algorithm}:{base64}")
     }
 }
 

--- a/ssh-key/src/known_hosts.rs
+++ b/ssh-key/src/known_hosts.rs
@@ -281,7 +281,7 @@ impl ToString for HostPatterns {
             HostPatterns::HashedName { salt, hash } => {
                 let salt = Base64::encode_string(salt);
                 let hash = Base64::encode_string(hash);
-                format!("|1|{}|{}", salt, hash)
+                format!("|1|{salt}|{hash}")
             }
         }
     }

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -167,20 +167,20 @@ impl Zeroize for MPInt {
 
 impl fmt::Debug for MPInt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "MPInt({:X})", self)
+        write!(f, "MPInt({self:X})")
     }
 }
 
 impl fmt::Display for MPInt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{self:X}")
     }
 }
 
 impl fmt::LowerHex for MPInt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_bytes() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -189,7 +189,7 @@ impl fmt::LowerHex for MPInt {
 impl fmt::UpperHex for MPInt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_bytes() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -151,7 +151,7 @@ use {
 };
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
@@ -339,7 +339,7 @@ impl PrivateKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn encrypt(
         &self,
-        mut rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         password: impl AsRef<[u8]>,
     ) -> Result<Self> {
         let checkint = rng.next_u32();
@@ -439,7 +439,7 @@ impl PrivateKey {
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[allow(unreachable_code, unused_variables)]
-    pub fn random(mut rng: impl CryptoRng + RngCore, algorithm: Algorithm) -> Result<Self> {
+    pub fn random(rng: &mut impl CryptoRngCore, algorithm: Algorithm) -> Result<Self> {
         let checkint = rng.next_u32();
         let key_data = match algorithm {
             #[cfg(feature = "dsa")]

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -8,7 +8,7 @@ use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) private key.
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
@@ -105,7 +105,7 @@ impl<const SIZE: usize> fmt::Debug for EcdsaPrivateKey<SIZE> {
 impl<const SIZE: usize> fmt::LowerHex for EcdsaPrivateKey<SIZE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -114,7 +114,7 @@ impl<const SIZE: usize> fmt::LowerHex for EcdsaPrivateKey<SIZE> {
 impl<const SIZE: usize> fmt::UpperHex for EcdsaPrivateKey<SIZE> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }
@@ -131,7 +131,7 @@ impl<const SIZE: usize> Drop for EcdsaPrivateKey<SIZE> {
 impl From<p256::SecretKey> for EcdsaPrivateKey<32> {
     fn from(sk: p256::SecretKey) -> EcdsaPrivateKey<32> {
         EcdsaPrivateKey {
-            bytes: sk.to_be_bytes().into(),
+            bytes: sk.to_bytes().into(),
         }
     }
 }
@@ -141,7 +141,7 @@ impl From<p256::SecretKey> for EcdsaPrivateKey<32> {
 impl From<p384::SecretKey> for EcdsaPrivateKey<48> {
     fn from(sk: p384::SecretKey) -> EcdsaPrivateKey<48> {
         EcdsaPrivateKey {
-            bytes: sk.to_be_bytes().into(),
+            bytes: sk.to_bytes().into(),
         }
     }
 }
@@ -183,7 +183,7 @@ impl EcdsaKeypair {
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[allow(unused_variables)]
-    pub fn random(rng: impl CryptoRng + RngCore, curve: EcdsaCurve) -> Result<Self> {
+    pub fn random(rng: &mut impl CryptoRngCore, curve: EcdsaCurve) -> Result<Self> {
         match curve {
             #[cfg(feature = "p256")]
             EcdsaCurve::NistP256 => {

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -77,7 +77,7 @@ impl fmt::Debug for Ed25519PrivateKey {
 impl fmt::LowerHex for Ed25519PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -86,7 +86,7 @@ impl fmt::LowerHex for Ed25519PrivateKey {
 impl fmt::UpperHex for Ed25519PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }
@@ -228,7 +228,7 @@ impl Decode for Ed25519Keypair {
         let mut bytes = Zeroizing::new([0u8; Self::BYTE_SIZE]);
         reader.read_prefixed(|reader| reader.read(&mut *bytes))?;
 
-        let keypair = Self::from_bytes(&*bytes)?;
+        let keypair = Self::from_bytes(&bytes)?;
 
         // Ensure public key matches the one one the keypair
         if keypair.public == public {

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -187,7 +187,7 @@ impl PublicKey {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_openssh_file(path: &Path) -> Result<Self> {
         let input = fs::read_to_string(path)?;
-        Self::from_openssh(&*input)
+        Self::from_openssh(&input)
     }
 
     /// Write public key as an OpenSSH-formatted file.

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -136,14 +136,14 @@ impl Encode for EcdsaPublicKey {
 
 impl fmt::Display for EcdsaPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{self:X}")
     }
 }
 
 impl fmt::LowerHex for EcdsaPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_sec1_bytes() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -152,7 +152,7 @@ impl fmt::LowerHex for EcdsaPublicKey {
 impl fmt::UpperHex for EcdsaPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_sec1_bytes() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -55,14 +55,14 @@ impl TryFrom<&[u8]> for Ed25519PublicKey {
 
 impl fmt::Display for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{self:X}")
     }
 }
 
 impl fmt::LowerHex for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -71,7 +71,7 @@ impl fmt::LowerHex for Ed25519PublicKey {
 impl fmt::UpperHex for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -252,7 +252,7 @@ impl fmt::Debug for Signature {
 impl fmt::LowerHex for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }
@@ -261,7 +261,7 @@ impl fmt::LowerHex for Signature {
 impl fmt::UpperHex for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_ref() {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }
@@ -585,7 +585,7 @@ impl Signer<Signature> for EcdsaKeypair {
 #[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl Signer<Signature> for EcdsaPrivateKey<32> {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
-        let signing_key = p256::ecdsa::SigningKey::from_bytes(self.as_ref())?;
+        let signing_key = p256::ecdsa::SigningKey::from_slice(self.as_ref())?;
         let signature: p256::ecdsa::Signature = signing_key.try_sign(message)?;
         Ok(signature.try_into()?)
     }
@@ -595,7 +595,7 @@ impl Signer<Signature> for EcdsaPrivateKey<32> {
 #[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl Signer<Signature> for EcdsaPrivateKey<48> {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
-        let signing_key = p384::ecdsa::SigningKey::from_bytes(self.as_ref())?;
+        let signing_key = p384::ecdsa::SigningKey::from_slice(self.as_ref())?;
         let signature: p384::ecdsa::Signature = signing_key.try_sign(message)?;
         Ok(signature.try_into()?)
     }


### PR DESCRIPTION
Bumps the following dependencies:

- `bcrypt-pbkdf` v0.10
- `dsa` v0.6
- `p256` v0.13
- `p384` v0.13
- `rand_core` v0.6.4 (for `CryptoRngCore`)
- `sec1` v0.7