### PR TITLE
ssh-key: use `&mut impl CryptoRngCore` for RNGs

### DIFF
--- a/ssh-key/src/certificate/builder.rs
+++ b/ssh-key/src/certificate/builder.rs
@@ -5,7 +5,7 @@ use crate::{public, Result, Signature, SigningKey};
 use alloc::{string::String, vec::Vec};
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 #[cfg(feature = "std")]
 use std::time::SystemTime;
@@ -159,7 +159,7 @@ impl Builder {
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     pub fn new_with_random_nonce(
-        mut rng: impl CryptoRng + RngCore,
+        rng: &mut impl CryptoRngCore,
         public_key: impl Into<public::KeyData>,
         valid_after: u64,
         valid_before: u64,

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -9,12 +9,7 @@ use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 use alloc::vec::Vec;
 
 #[cfg(feature = "encryption")]
-use {
-    crate::Cipher,
-    bcrypt_pbkdf::bcrypt_pbkdf,
-    rand_core::{CryptoRng, RngCore},
-    zeroize::Zeroizing,
-};
+use {crate::Cipher, bcrypt_pbkdf::bcrypt_pbkdf, rand_core::CryptoRngCore, zeroize::Zeroizing};
 
 /// Default number of rounds to use for bcrypt-pbkdf.
 #[cfg(feature = "encryption")]
@@ -47,7 +42,7 @@ impl Kdf {
     /// Initialize KDF configuration for the given algorithm.
     #[cfg(feature = "encryption")]
     #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
-    pub fn new(algorithm: KdfAlg, mut rng: impl CryptoRng + RngCore) -> Result<Self> {
+    pub fn new(algorithm: KdfAlg, rng: &mut impl CryptoRngCore) -> Result<Self> {
         let mut salt = vec![0u8; DEFAULT_SALT_SIZE];
         rng.fill_bytes(&mut salt);
 

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -7,7 +7,7 @@ use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
 #[cfg(all(feature = "dsa", feature = "rand_core"))]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// Digital Signature Algorithm (DSA) private key.
 ///
@@ -150,9 +150,9 @@ impl DsaKeypair {
     /// Generate a random DSA private key.
     #[cfg(all(feature = "dsa", feature = "rand_core"))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "dsa", feature = "rand_core"))))]
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Result<Self> {
-        let components = dsa::Components::generate(&mut rng, Self::KEY_SIZE);
-        dsa::SigningKey::generate(&mut rng, components).try_into()
+    pub fn random(rng: &mut impl CryptoRngCore) -> Result<Self> {
+        let components = dsa::Components::generate(rng, Self::KEY_SIZE);
+        dsa::SigningKey::generate(rng, components).try_into()
     }
 }
 

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -9,7 +9,7 @@ use subtle::{Choice, ConstantTimeEq};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "rand_core")]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 /// Ed25519 private key.
 // TODO(tarcieri): use `ed25519::PrivateKey`? (doesn't exist yet)
@@ -23,7 +23,7 @@ impl Ed25519PrivateKey {
     /// Generate a random Ed25519 private key.
     #[cfg(feature = "rand_core")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
-    pub fn random(mut rng: impl CryptoRng + RngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         let mut key_bytes = [0u8; Self::BYTE_SIZE];
         rng.fill_bytes(&mut key_bytes);
         Self(key_bytes)
@@ -165,7 +165,7 @@ impl Ed25519Keypair {
     /// Generate a random Ed25519 private keypair.
     #[cfg(feature = "ed25519")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
-    pub fn random(rng: impl CryptoRng + RngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         Ed25519PrivateKey::random(rng).into()
     }
 

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroize;
 
 #[cfg(feature = "rsa")]
 use {
-    rand_core::{CryptoRng, RngCore},
+    rand_core::CryptoRngCore,
     rsa::{pkcs1v15, PublicKeyParts},
     sha2::{digest::const_oid::AssociatedOid, Digest},
 };
@@ -109,9 +109,9 @@ impl RsaKeypair {
     /// Generate a random RSA keypair of the given size.
     #[cfg(feature = "rsa")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
-    pub fn random(mut rng: impl CryptoRng + RngCore, bit_size: usize) -> Result<Self> {
+    pub fn random(rng: &mut impl CryptoRngCore, bit_size: usize) -> Result<Self> {
         if bit_size >= Self::MIN_KEY_SIZE {
-            rsa::RsaPrivateKey::new(&mut rng, bit_size)?.try_into()
+            rsa::RsaPrivateKey::new(rng, bit_size)?.try_into()
         } else {
             Err(Error::Crypto)
         }


### PR DESCRIPTION
Alias added in `rand_core` v0.6.4 with a blanket impl for `CryptoRng + RngCore`.

Using a mut reference avoids reborrowing.

For more context, see RustCrypto/traits#1148.