### PR TITLE
ssh-encoding: use `doc_auto_cfg`

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -30,7 +30,6 @@ pub trait Decode: Sized {
 /// This is an extension trait which is auto-impl'd for types which impl the
 /// [`Decode`], [`PemLabel`], and [`Sized`] traits.
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub trait DecodePem: Decode + PemLabel + Sized {
     /// Decode the provided PEM-encoded string, interpreting the Base64-encoded
     /// body of the document using the [`Decode`] trait.
@@ -38,7 +37,6 @@ pub trait DecodePem: Decode + PemLabel + Sized {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<T: Decode + PemLabel + Sized> DecodePem for T {
     fn decode_pem(pem: impl AsRef<[u8]>) -> core::result::Result<Self, Self::Error> {
         let mut reader =
@@ -142,7 +140,6 @@ impl<const N: usize> Decode for [u8; N] {
 ///
 /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Decode for Vec<u8> {
     type Error = Error;
 
@@ -156,7 +153,6 @@ impl Decode for Vec<u8> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Decode for String {
     type Error = Error;
 
@@ -166,7 +162,6 @@ impl Decode for String {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Decode for Vec<String> {
     type Error = Error;
 

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -47,7 +47,6 @@ pub trait Encode {
 /// This is an extension trait which is auto-impl'd for types which impl the
 /// [`Encode`] and [`PemLabel`] traits.
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 pub trait EncodePem: Encode + PemLabel {
     /// Encode this type using the [`Encode`] trait, writing the resulting PEM
     /// document into the provided `out` buffer.
@@ -60,12 +59,10 @@ pub trait EncodePem: Encode + PemLabel {
     /// Encode this type using the [`Encode`] trait, writing the resulting PEM
     /// document to a returned [`String`].
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     fn encode_pem_string(&self, line_ending: LineEnding) -> Result<String, Self::Error>;
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl<T: Encode + PemLabel> EncodePem for T {
     fn encode_pem<'o>(
         &self,
@@ -235,7 +232,6 @@ impl Encode for &str {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Encode for Vec<u8> {
     type Error = Error;
 
@@ -249,7 +245,6 @@ impl Encode for Vec<u8> {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Encode for String {
     type Error = Error;
 
@@ -263,7 +258,6 @@ impl Encode for String {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Encode for Vec<String> {
     type Error = Error;
 

--- a/ssh-encoding/src/error.rs
+++ b/ssh-encoding/src/error.rs
@@ -9,9 +9,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
-    #[cfg(feature = "base64")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
     /// Base64-related errors.
+    #[cfg(feature = "base64")]
     Base64(base64::Error),
 
     /// Character encoding-related errors.
@@ -65,7 +64,6 @@ impl From<core::str::Utf8Error> for Error {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<alloc::string::FromUtf8Error> for Error {
     fn from(_: alloc::string::FromUtf8Error) -> Error {
         Error::CharacterEncoding
@@ -73,7 +71,6 @@ impl From<alloc::string::FromUtf8Error> for Error {
 }
 
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 impl From<base64::Error> for Error {
     fn from(err: base64::Error) -> Error {
         Error::Base64(err)
@@ -81,7 +78,6 @@ impl From<base64::Error> for Error {
 }
 
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 impl From<base64::InvalidLengthError> for Error {
     fn from(_: base64::InvalidLengthError) -> Error {
         Error::Length
@@ -89,7 +85,6 @@ impl From<base64::InvalidLengthError> for Error {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl From<pem::Error> for Error {
     fn from(err: pem::Error) -> Error {
         Error::Pem(err)
@@ -97,7 +92,6 @@ impl From<pem::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",

--- a/ssh-encoding/src/reader.rs
+++ b/ssh-encoding/src/reader.rs
@@ -5,7 +5,6 @@ use core::str;
 
 /// Constant-time Base64 reader implementation.
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 pub type Base64Reader<'i> = base64::Decoder<'i, base64::Base64>;
 
 /// Reader trait which decodes the binary SSH protocol serialization from
@@ -147,7 +146,6 @@ impl Reader for &[u8] {
 }
 
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 impl Reader for Base64Reader<'_> {
     fn read<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         Ok(self.decode(out)?)
@@ -159,7 +157,6 @@ impl Reader for Base64Reader<'_> {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl Reader for pem::Decoder<'_> {
     fn read<'o>(&mut self, out: &'o mut [u8]) -> Result<&'o [u8]> {
         Ok(self.decode(out)?)

--- a/ssh-encoding/src/writer.rs
+++ b/ssh-encoding/src/writer.rs
@@ -10,7 +10,6 @@ use sha2::{Digest, Sha256, Sha512};
 
 /// Constant-time Base64 writer implementation.
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 pub type Base64Writer<'o> = base64::Encoder<'o, base64::Base64>;
 
 /// Writer trait which encodes the SSH binary format to various output
@@ -21,7 +20,6 @@ pub trait Writer: Sized {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Writer for Vec<u8> {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.extend_from_slice(bytes);
@@ -30,7 +28,6 @@ impl Writer for Vec<u8> {
 }
 
 #[cfg(feature = "base64")]
-#[cfg_attr(docsrs, doc(cfg(feature = "base64")))]
 impl Writer for Base64Writer<'_> {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         Ok(self.encode(bytes)?)
@@ -38,7 +35,6 @@ impl Writer for Base64Writer<'_> {
 }
 
 #[cfg(feature = "pem")]
-#[cfg_attr(docsrs, doc(cfg(feature = "pem")))]
 impl Writer for pem::Encoder<'_, '_> {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         Ok(self.encode(bytes)?)
@@ -46,7 +42,6 @@ impl Writer for pem::Encoder<'_, '_> {
 }
 
 #[cfg(feature = "sha2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha2")))]
 impl Writer for Sha256 {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.update(bytes);
@@ -55,7 +50,6 @@ impl Writer for Sha256 {
 }
 
 #[cfg(feature = "sha2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sha2")))]
 impl Writer for Sha512 {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.update(bytes);


### PR DESCRIPTION
Automatically generate feature-specific annotations for documentation rather than relying on manual ones