### PR TITLE
ssh-key: use `doc_auto_cfg`

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -400,7 +400,6 @@ impl HashAlg {
 
     /// Compute a digest of the given message using this hash function.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn digest(self, msg: &[u8]) -> Vec<u8> {
         match self {
             HashAlg::Sha256 => Sha256::digest(msg).to_vec(),

--- a/ssh-key/src/authorized_keys.rs
+++ b/ssh-key/src/authorized_keys.rs
@@ -50,7 +50,6 @@ impl<'a> AuthorizedKeys<'a> {
     /// Read an [`AuthorizedKeys`] file from the filesystem, returning an
     /// [`Entry`] vector on success.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_file(path: impl AsRef<Path>) -> Result<Vec<Entry>> {
         // TODO(tarcieri): permissions checks
         let input = fs::read_to_string(path)?;
@@ -101,7 +100,6 @@ pub struct Entry {
 impl Entry {
     /// Get configuration options for this entry.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn config_opts(&self) -> &ConfigOpts {
         &self.config_opts
     }
@@ -186,7 +184,6 @@ impl ToString for Entry {
 /// The [`ConfigOpts::iter`] method can be used to iterate over each
 /// comma-separated value.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ConfigOpts(String);
 

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -205,7 +205,6 @@ impl Certificate {
 
     /// Read OpenSSH certificate from a file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_file(path: &Path) -> Result<Self> {
         let input = fs::read_to_string(path)?;
         Self::from_openssh(&input)
@@ -213,7 +212,6 @@ impl Certificate {
 
     /// Write OpenSSH certificate to a file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write_file(&self, path: &Path) -> Result<()> {
         let encoded = self.to_openssh()?;
         fs::write(path, encoded.as_bytes())?;
@@ -291,14 +289,12 @@ impl Certificate {
 
     /// Valid after (system time).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn valid_after_time(&self) -> SystemTime {
         self.valid_after.into()
     }
 
     /// Valid before (system time).
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn valid_before_time(&self) -> SystemTime {
         self.valid_before.into()
     }
@@ -343,7 +339,6 @@ impl Certificate {
     /// See [`Certificate::validate_at`] documentation for important notes on
     /// how to properly validate certificates!
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn validate<'a, I>(&self, ca_fingerprints: I) -> Result<()>
     where
         I: IntoIterator<Item = &'a Fingerprint>,
@@ -519,7 +514,6 @@ impl ToString for Certificate {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> Deserialize<'de> for Certificate {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
@@ -536,7 +530,6 @@ impl<'de> Deserialize<'de> for Certificate {
 }
 
 #[cfg(feature = "serde")]
-#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl Serialize for Certificate {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where

--- a/ssh-key/src/certificate/builder.rs
+++ b/ssh-key/src/certificate/builder.rs
@@ -128,7 +128,6 @@ impl Builder {
     /// Create a new certificate builder with the validity window specified
     /// using [`SystemTime`] values.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn new_with_validity_times(
         nonce: impl Into<Vec<u8>>,
         public_key: impl Into<public::KeyData>,
@@ -157,7 +156,6 @@ impl Builder {
     /// Create a new certificate builder, generating a random nonce using the
     /// provided random number generator.
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     pub fn new_with_random_nonce(
         rng: &mut impl CryptoRngCore,
         public_key: impl Into<public::KeyData>,

--- a/ssh-key/src/cipher.rs
+++ b/ssh-key/src/cipher.rs
@@ -89,7 +89,6 @@ impl Cipher {
 
     /// Decrypt the ciphertext in the `buffer` in-place using this cipher.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn decrypt(self, key: &[u8], iv: &[u8], buffer: &mut [u8]) -> Result<()> {
         match self {
             Self::None => return Err(Error::Crypto),
@@ -102,7 +101,6 @@ impl Cipher {
 
     /// Encrypt the ciphertext in the `buffer` in-place using this cipher.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn encrypt(self, key: &[u8], iv: &[u8], buffer: &mut [u8]) -> Result<()> {
         match self {
             Self::None => return Err(Error::Crypto),

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -17,7 +17,6 @@ pub enum Error {
 
     /// Certificate field is invalid or already set.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     CertificateFieldInvalid(certificate::Field),
 
     /// Certificate validation failed.
@@ -31,7 +30,6 @@ pub enum Error {
 
     /// ECDSA key encoding errors.
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     Ecdsa(sec1::Error),
 
     /// Encoding errors.
@@ -45,7 +43,6 @@ pub enum Error {
 
     /// Input/output errors.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Io(std::io::ErrorKind),
 
     /// Namespace invalid.
@@ -143,7 +140,6 @@ impl From<Error> for signature::Error {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<alloc::string::FromUtf8Error> for Error {
     fn from(err: alloc::string::FromUtf8Error) -> Error {
         Error::Encoding(err.into())
@@ -151,7 +147,6 @@ impl From<alloc::string::FromUtf8Error> for Error {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<sec1::Error> for Error {
     fn from(err: sec1::Error) -> Error {
         Error::Ecdsa(err)
@@ -159,7 +154,6 @@ impl From<sec1::Error> for Error {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl From<rsa::errors::Error> for Error {
     fn from(_: rsa::errors::Error) -> Error {
         Error::Crypto
@@ -167,7 +161,6 @@ impl From<rsa::errors::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error::Io(err.kind())
@@ -175,7 +168,6 @@ impl From<std::io::Error> for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<std::time::SystemTimeError> for Error {
     fn from(_: std::time::SystemTimeError) -> Error {
         Error::Time
@@ -183,7 +175,6 @@ impl From<std::time::SystemTimeError> for Error {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/ssh-key/src/fingerprint.rs
+++ b/ssh-key/src/fingerprint.rs
@@ -160,7 +160,6 @@ impl FromStr for Fingerprint {
 }
 
 #[cfg(all(feature = "alloc", feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "serde"))))]
 impl<'de> Deserialize<'de> for Fingerprint {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
@@ -172,7 +171,6 @@ impl<'de> Deserialize<'de> for Fingerprint {
 }
 
 #[cfg(all(feature = "alloc", feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "serde"))))]
 impl Serialize for Fingerprint {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -28,7 +28,6 @@ pub enum Kdf {
 
     /// bcrypt-pbkdf options.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Bcrypt {
         /// Salt
         salt: Vec<u8>,
@@ -41,7 +40,6 @@ pub enum Kdf {
 impl Kdf {
     /// Initialize KDF configuration for the given algorithm.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn new(algorithm: KdfAlg, rng: &mut impl CryptoRngCore) -> Result<Self> {
         let mut salt = vec![0u8; DEFAULT_SALT_SIZE];
         rng.fill_bytes(&mut salt);
@@ -69,7 +67,6 @@ impl Kdf {
 
     /// Derive an encryption key from the given password.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn derive(&self, password: impl AsRef<[u8]>, output: &mut [u8]) -> Result<()> {
         match self {
             Kdf::None => Err(Error::Decrypted),
@@ -84,7 +81,6 @@ impl Kdf {
     ///
     /// Returns two byte vectors containing the key and IV respectively.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn derive_key_and_iv(
         &self,
         cipher: Cipher,
@@ -113,7 +109,6 @@ impl Kdf {
 
     /// Is the KDF configured as `bcrypt` (i.e. bcrypt-pbkdf)?
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn is_bcrypt(&self) -> bool {
         matches!(self, Self::Bcrypt { .. })
     }

--- a/ssh-key/src/known_hosts.rs
+++ b/ssh-key/src/known_hosts.rs
@@ -60,7 +60,6 @@ impl<'a> KnownHosts<'a> {
     /// Read a [`KnownHosts`] file from the filesystem, returning an
     /// [`Entry`] vector on success.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_file(path: impl AsRef<Path>) -> Result<Vec<Entry>> {
         // TODO(tarcieri): permissions checks
         let input = fs::read_to_string(path)?;

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
@@ -139,15 +139,13 @@ extern crate alloc;
 extern crate std;
 
 pub mod authorized_keys;
-#[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub mod known_hosts;
 pub mod private;
 pub mod public;
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod certificate;
+#[cfg(feature = "alloc")]
+pub mod known_hosts;
 
 mod algorithm;
 mod cipher;

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -38,8 +38,6 @@ use zeroize::Zeroizing;
 /// | 80              | `00 00 00 02 00 80`
 /// |-1234            | `00 00 00 02 ed cc`
 /// | -deadbeef       | `00 00 00 05 ff 21 52 41 11`
-// TODO(tarcieri): support for heapless platforms
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, PartialOrd, Ord)]
 pub struct MPInt {
     /// Inner big endian-serialized integer value
@@ -196,7 +194,6 @@ impl fmt::UpperHex for MPInt {
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
 impl TryFrom<bigint::BigUint> for MPInt {
     type Error = Error;
 
@@ -206,7 +203,6 @@ impl TryFrom<bigint::BigUint> for MPInt {
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
 impl TryFrom<&bigint::BigUint> for MPInt {
     type Error = Error;
 
@@ -217,7 +213,6 @@ impl TryFrom<&bigint::BigUint> for MPInt {
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
 impl TryFrom<MPInt> for bigint::BigUint {
     type Error = Error;
 
@@ -227,7 +222,6 @@ impl TryFrom<MPInt> for bigint::BigUint {
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "dsa", feature = "rsa"))))]
 impl TryFrom<&MPInt> for bigint::BigUint {
     type Error = Error;
 

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -205,7 +205,6 @@ impl PrivateKey {
     ///
     /// On `no_std` platforms, use `PrivateKey::from(key_data)` instead.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn new(key_data: KeypairData, comment: impl Into<String>) -> Result<Self> {
         if key_data.is_encrypted() {
             return Err(Error::Encrypted);
@@ -246,14 +245,12 @@ impl PrivateKey {
     /// Encode an OpenSSH-formatted PEM private key, allocating a
     /// self-zeroizing [`String`] for the result.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_openssh(&self, line_ending: LineEnding) -> Result<Zeroizing<String>> {
         self.encode_pem_string(line_ending).map(Zeroizing::new)
     }
 
     /// Serialize SSH private key as raw bytes.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_bytes(&self) -> Result<Zeroizing<Vec<u8>>> {
         let mut private_key_bytes = Vec::with_capacity(self.encoded_len()?);
         self.encode(&mut private_key_bytes)?;
@@ -273,14 +270,12 @@ impl PrivateKey {
     ///
     /// [PROTOCOL.sshsig]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.sshsig?annotate=HEAD
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn sign(&self, namespace: &str, hash_alg: HashAlg, msg: &[u8]) -> Result<SshSig> {
         SshSig::sign(self, namespace, hash_alg, msg)
     }
 
     /// Read private key from an OpenSSH-formatted PEM file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_openssh_file(path: &Path) -> Result<Self> {
         // TODO(tarcieri): verify file permissions match `UNIX_FILE_PERMISSIONS`
         let pem = Zeroizing::new(fs::read_to_string(path)?);
@@ -289,7 +284,6 @@ impl PrivateKey {
 
     /// Write private key as an OpenSSH-formatted PEM file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write_openssh_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
         let pem = self.to_openssh(line_ending)?;
 
@@ -312,7 +306,6 @@ impl PrivateKey {
     ///
     /// Returns [`Error::Decrypted`] if the private key is already decrypted.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn decrypt(&self, password: impl AsRef<[u8]>) -> Result<Self> {
         let (key_bytes, iv_bytes) = self.kdf.derive_key_and_iv(self.cipher, password)?;
 
@@ -336,7 +329,6 @@ impl PrivateKey {
     ///
     /// Returns [`Error::Encrypted`] if the private key is already encrypted.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn encrypt(
         &self,
         rng: &mut impl CryptoRngCore,
@@ -357,7 +349,6 @@ impl PrivateKey {
     ///
     /// Returns [`Error::Encrypted`] if the private key is already encrypted.
     #[cfg(feature = "encryption")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "encryption")))]
     pub fn encrypt_with(
         &self,
         cipher: Cipher,
@@ -437,7 +428,6 @@ impl PrivateKey {
     /// # Returns
     /// - `Error::Algorithm` if the algorithm is unsupported.
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[allow(unreachable_code, unused_variables)]
     pub fn random(rng: &mut impl CryptoRngCore, algorithm: Algorithm) -> Result<Self> {
         let checkint = rng.next_u32();
@@ -467,7 +457,6 @@ impl PrivateKey {
 
     /// Set the comment on the key.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn set_comment(&mut self, comment: impl Into<String>) {
         self.public_key.set_comment(comment);
     }
@@ -754,7 +743,6 @@ impl From<&PrivateKey> for public::KeyData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<DsaKeypair> for PrivateKey {
     fn from(keypair: DsaKeypair) -> PrivateKey {
         KeypairData::from(keypair)
@@ -764,7 +752,6 @@ impl From<DsaKeypair> for PrivateKey {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<EcdsaKeypair> for PrivateKey {
     fn from(keypair: EcdsaKeypair) -> PrivateKey {
         KeypairData::from(keypair)
@@ -782,7 +769,6 @@ impl From<Ed25519Keypair> for PrivateKey {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<RsaKeypair> for PrivateKey {
     fn from(keypair: RsaKeypair) -> PrivateKey {
         KeypairData::from(keypair)
@@ -792,7 +778,6 @@ impl From<RsaKeypair> for PrivateKey {
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
 impl From<SkEcdsaSha2NistP256> for PrivateKey {
     fn from(keypair: SkEcdsaSha2NistP256) -> PrivateKey {
         KeypairData::from(keypair)
@@ -802,7 +787,6 @@ impl From<SkEcdsaSha2NistP256> for PrivateKey {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<SkEd25519> for PrivateKey {
     fn from(keypair: SkEd25519) -> PrivateKey {
         KeypairData::from(keypair)

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -15,7 +15,6 @@ use rand_core::CryptoRngCore;
 /// range `[1, q–1]`.
 ///
 /// Described in [FIPS 186-4 § 4.1](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
 pub struct DsaPrivateKey {
     /// Integer representing a DSA private key.
@@ -89,7 +88,6 @@ impl Drop for DsaPrivateKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<DsaPrivateKey> for dsa::BigUint {
     type Error = Error;
 
@@ -99,7 +97,6 @@ impl TryFrom<DsaPrivateKey> for dsa::BigUint {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<&DsaPrivateKey> for dsa::BigUint {
     type Error = Error;
 
@@ -109,7 +106,6 @@ impl TryFrom<&DsaPrivateKey> for dsa::BigUint {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<dsa::SigningKey> for DsaPrivateKey {
     type Error = Error;
 
@@ -119,7 +115,6 @@ impl TryFrom<dsa::SigningKey> for DsaPrivateKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<&dsa::SigningKey> for DsaPrivateKey {
     type Error = Error;
 
@@ -131,7 +126,6 @@ impl TryFrom<&dsa::SigningKey> for DsaPrivateKey {
 }
 
 /// Digital Signature Algorithm (DSA) private/public keypair.
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
 pub struct DsaKeypair {
     /// Public key.
@@ -149,7 +143,6 @@ impl DsaKeypair {
 
     /// Generate a random DSA private key.
     #[cfg(all(feature = "dsa", feature = "rand_core"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "dsa", feature = "rand_core"))))]
     pub fn random(rng: &mut impl CryptoRngCore) -> Result<Self> {
         let components = dsa::Components::generate(rng, Self::KEY_SIZE);
         dsa::SigningKey::generate(rng, components).try_into()
@@ -214,7 +207,6 @@ impl fmt::Debug for DsaKeypair {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<DsaKeypair> for dsa::SigningKey {
     type Error = Error;
 
@@ -224,7 +216,6 @@ impl TryFrom<DsaKeypair> for dsa::SigningKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<&DsaKeypair> for dsa::SigningKey {
     type Error = Error;
 
@@ -237,7 +228,6 @@ impl TryFrom<&DsaKeypair> for dsa::SigningKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<dsa::SigningKey> for DsaKeypair {
     type Error = Error;
 
@@ -247,7 +237,6 @@ impl TryFrom<dsa::SigningKey> for DsaKeypair {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<&dsa::SigningKey> for DsaKeypair {
     type Error = Error;
 

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -11,7 +11,6 @@ use zeroize::Zeroize;
 use rand_core::CryptoRngCore;
 
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) private key.
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Clone)]
 pub struct EcdsaPrivateKey<const SIZE: usize> {
     /// Byte array containing serialized big endian private scalar.
@@ -127,7 +126,6 @@ impl<const SIZE: usize> Drop for EcdsaPrivateKey<SIZE> {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl From<p256::SecretKey> for EcdsaPrivateKey<32> {
     fn from(sk: p256::SecretKey) -> EcdsaPrivateKey<32> {
         EcdsaPrivateKey {
@@ -137,7 +135,6 @@ impl From<p256::SecretKey> for EcdsaPrivateKey<32> {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl From<p384::SecretKey> for EcdsaPrivateKey<48> {
     fn from(sk: p384::SecretKey) -> EcdsaPrivateKey<48> {
         EcdsaPrivateKey {
@@ -147,7 +144,6 @@ impl From<p384::SecretKey> for EcdsaPrivateKey<48> {
 }
 
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) private/public keypair.
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Clone, Debug)]
 pub enum EcdsaKeypair {
     /// NIST P-256 ECDSA keypair.
@@ -181,7 +177,6 @@ pub enum EcdsaKeypair {
 impl EcdsaKeypair {
     /// Generate a random ECDSA private key.
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     #[allow(unused_variables)]
     pub fn random(rng: &mut impl CryptoRngCore, curve: EcdsaCurve) -> Result<Self> {
         match curve {

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -22,7 +22,6 @@ impl Ed25519PrivateKey {
 
     /// Generate a random Ed25519 private key.
     #[cfg(feature = "rand_core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand_core")))]
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         let mut key_bytes = [0u8; Self::BYTE_SIZE];
         rng.fill_bytes(&mut key_bytes);
@@ -99,7 +98,6 @@ impl Drop for Ed25519PrivateKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<Ed25519PrivateKey> for ed25519_dalek::SigningKey {
     fn from(key: Ed25519PrivateKey) -> ed25519_dalek::SigningKey {
         ed25519_dalek::SigningKey::from(&key)
@@ -107,7 +105,6 @@ impl From<Ed25519PrivateKey> for ed25519_dalek::SigningKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<&Ed25519PrivateKey> for ed25519_dalek::SigningKey {
     fn from(key: &Ed25519PrivateKey) -> ed25519_dalek::SigningKey {
         ed25519_dalek::SigningKey::from_bytes(key.as_ref())
@@ -115,7 +112,6 @@ impl From<&Ed25519PrivateKey> for ed25519_dalek::SigningKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<ed25519_dalek::SigningKey> for Ed25519PrivateKey {
     fn from(key: ed25519_dalek::SigningKey) -> Ed25519PrivateKey {
         Ed25519PrivateKey::from(&key)
@@ -123,7 +119,6 @@ impl From<ed25519_dalek::SigningKey> for Ed25519PrivateKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<&ed25519_dalek::SigningKey> for Ed25519PrivateKey {
     fn from(key: &ed25519_dalek::SigningKey) -> Ed25519PrivateKey {
         Ed25519PrivateKey(key.to_bytes())
@@ -131,7 +126,6 @@ impl From<&ed25519_dalek::SigningKey> for Ed25519PrivateKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<Ed25519PrivateKey> for Ed25519PublicKey {
     fn from(private: Ed25519PrivateKey) -> Ed25519PublicKey {
         Ed25519PublicKey::from(&private)
@@ -139,7 +133,6 @@ impl From<Ed25519PrivateKey> for Ed25519PublicKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<&Ed25519PrivateKey> for Ed25519PublicKey {
     fn from(private: &Ed25519PrivateKey) -> Ed25519PublicKey {
         ed25519_dalek::SigningKey::from(private)
@@ -164,14 +157,12 @@ impl Ed25519Keypair {
 
     /// Generate a random Ed25519 private keypair.
     #[cfg(feature = "ed25519")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
     pub fn random(rng: &mut impl CryptoRngCore) -> Self {
         Ed25519PrivateKey::random(rng).into()
     }
 
     /// Expand a keypair from a 32-byte seed value.
     #[cfg(feature = "ed25519")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
     pub fn from_seed(seed: &[u8; Ed25519PrivateKey::BYTE_SIZE]) -> Self {
         Ed25519PrivateKey::from_bytes(seed).into()
     }
@@ -282,7 +273,6 @@ impl fmt::Debug for Ed25519Keypair {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<Ed25519PrivateKey> for Ed25519Keypair {
     fn from(private: Ed25519PrivateKey) -> Ed25519Keypair {
         let secret = ed25519_dalek::SigningKey::from(&private);
@@ -292,7 +282,6 @@ impl From<Ed25519PrivateKey> for Ed25519Keypair {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl TryFrom<Ed25519Keypair> for ed25519_dalek::SigningKey {
     type Error = Error;
 
@@ -302,7 +291,6 @@ impl TryFrom<Ed25519Keypair> for ed25519_dalek::SigningKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl TryFrom<&Ed25519Keypair> for ed25519_dalek::SigningKey {
     type Error = Error;
 
@@ -319,7 +307,6 @@ impl TryFrom<&Ed25519Keypair> for ed25519_dalek::SigningKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<ed25519_dalek::SigningKey> for Ed25519Keypair {
     fn from(key: ed25519_dalek::SigningKey) -> Ed25519Keypair {
         Ed25519Keypair::from(&key)
@@ -327,7 +314,6 @@ impl From<ed25519_dalek::SigningKey> for Ed25519Keypair {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<&ed25519_dalek::SigningKey> for Ed25519Keypair {
     fn from(key: &ed25519_dalek::SigningKey) -> Ed25519Keypair {
         Ed25519Keypair {

--- a/ssh-key/src/private/keypair.rs
+++ b/ssh-key/src/private/keypair.rs
@@ -27,12 +27,10 @@ use super::SkEcdsaSha2NistP256;
 pub enum KeypairData {
     /// Digital Signature Algorithm (DSA) keypair.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Dsa(DsaKeypair),
 
     /// ECDSA keypair.
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     Ecdsa(EcdsaKeypair),
 
     /// Ed25519 keypair.
@@ -40,26 +38,22 @@ pub enum KeypairData {
 
     /// Encrypted private key (ciphertext).
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Encrypted(Vec<u8>),
 
     /// RSA keypair.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Rsa(RsaKeypair),
 
     /// Security Key (FIDO/U2F) using ECDSA/NIST P-256 as specified in [PROTOCOL.u2f].
     ///
     /// [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
     #[cfg(all(feature = "alloc", feature = "ecdsa"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
     SkEcdsaSha2NistP256(SkEcdsaSha2NistP256),
 
     /// Security Key (FIDO/U2F) using Ed25519 as specified in [PROTOCOL.u2f].
     ///
     /// [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     SkEd25519(SkEd25519),
 }
 
@@ -85,7 +79,6 @@ impl KeypairData {
 
     /// Get DSA keypair if this key is the correct type.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn dsa(&self) -> Option<&DsaKeypair> {
         match self {
             Self::Dsa(key) => Some(key),
@@ -95,7 +88,6 @@ impl KeypairData {
 
     /// Get ECDSA private key if this key is the correct type.
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn ecdsa(&self) -> Option<&EcdsaKeypair> {
         match self {
             Self::Ecdsa(keypair) => Some(keypair),
@@ -114,7 +106,6 @@ impl KeypairData {
 
     /// Get the encrypted ciphertext if this key is encrypted.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn encrypted(&self) -> Option<&[u8]> {
         match self {
             Self::Encrypted(ciphertext) => Some(ciphertext),
@@ -124,7 +115,6 @@ impl KeypairData {
 
     /// Get RSA keypair if this key is the correct type.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn rsa(&self) -> Option<&RsaKeypair> {
         match self {
             Self::Rsa(key) => Some(key),
@@ -134,7 +124,6 @@ impl KeypairData {
 
     /// Get FIDO/U2F ECDSA/NIST P-256 private key if this key is the correct type.
     #[cfg(all(feature = "alloc", feature = "ecdsa"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
     pub fn sk_ecdsa_p256(&self) -> Option<&SkEcdsaSha2NistP256> {
         match self {
             Self::SkEcdsaSha2NistP256(sk) => Some(sk),
@@ -144,7 +133,6 @@ impl KeypairData {
 
     /// Get FIDO/U2F Ed25519 private key if this key is the correct type.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn sk_ed25519(&self) -> Option<&SkEd25519> {
         match self {
             Self::SkEd25519(sk) => Some(sk),
@@ -154,14 +142,12 @@ impl KeypairData {
 
     /// Is this key a DSA key?
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn is_dsa(&self) -> bool {
         matches!(self, Self::Dsa(_))
     }
 
     /// Is this key an ECDSA key?
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn is_ecdsa(&self) -> bool {
         matches!(self, Self::Ecdsa(_))
     }
@@ -185,21 +171,18 @@ impl KeypairData {
 
     /// Is this key an RSA key?
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn is_rsa(&self) -> bool {
         matches!(self, Self::Rsa(_))
     }
 
     /// Is this key a FIDO/U2F ECDSA/NIST P-256 key?
     #[cfg(all(feature = "alloc", feature = "ecdsa"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
     pub fn is_sk_ecdsa_p256(&self) -> bool {
         matches!(self, Self::SkEcdsaSha2NistP256(_))
     }
 
     /// Is this key a FIDO/U2F Ed25519 key?
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn is_sk_ed25519(&self) -> bool {
         matches!(self, Self::SkEd25519(_))
     }
@@ -374,7 +357,6 @@ impl TryFrom<&KeypairData> for public::KeyData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<DsaKeypair> for KeypairData {
     fn from(keypair: DsaKeypair) -> KeypairData {
         Self::Dsa(keypair)
@@ -382,7 +364,6 @@ impl From<DsaKeypair> for KeypairData {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<EcdsaKeypair> for KeypairData {
     fn from(keypair: EcdsaKeypair) -> KeypairData {
         Self::Ecdsa(keypair)
@@ -396,7 +377,6 @@ impl From<Ed25519Keypair> for KeypairData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<RsaKeypair> for KeypairData {
     fn from(keypair: RsaKeypair) -> KeypairData {
         Self::Rsa(keypair)
@@ -404,7 +384,6 @@ impl From<RsaKeypair> for KeypairData {
 }
 
 #[cfg(all(feature = "alloc", feature = "ecdsa"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
 impl From<SkEcdsaSha2NistP256> for KeypairData {
     fn from(keypair: SkEcdsaSha2NistP256) -> KeypairData {
         Self::SkEcdsaSha2NistP256(keypair)
@@ -412,7 +391,6 @@ impl From<SkEcdsaSha2NistP256> for KeypairData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<SkEd25519> for KeypairData {
     fn from(keypair: SkEd25519) -> KeypairData {
         Self::SkEd25519(keypair)

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -14,7 +14,6 @@ use {
 };
 
 /// RSA private key.
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
 pub struct RsaPrivateKey {
     /// RSA private exponent.
@@ -91,7 +90,6 @@ impl Drop for RsaPrivateKey {
 }
 
 /// RSA private/public keypair.
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone)]
 pub struct RsaKeypair {
     /// Public key.
@@ -108,7 +106,6 @@ impl RsaKeypair {
 
     /// Generate a random RSA keypair of the given size.
     #[cfg(feature = "rsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
     pub fn random(rng: &mut impl CryptoRngCore, bit_size: usize) -> Result<Self> {
         if bit_size >= Self::MIN_KEY_SIZE {
             rsa::RsaPrivateKey::new(rng, bit_size)?.try_into()
@@ -184,7 +181,6 @@ impl fmt::Debug for RsaKeypair {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<RsaKeypair> for rsa::RsaPrivateKey {
     type Error = Error;
 
@@ -194,7 +190,6 @@ impl TryFrom<RsaKeypair> for rsa::RsaPrivateKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<&RsaKeypair> for rsa::RsaPrivateKey {
     type Error = Error;
 
@@ -218,7 +213,6 @@ impl TryFrom<&RsaKeypair> for rsa::RsaPrivateKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<rsa::RsaPrivateKey> for RsaKeypair {
     type Error = Error;
 
@@ -228,7 +222,6 @@ impl TryFrom<rsa::RsaPrivateKey> for RsaKeypair {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<&rsa::RsaPrivateKey> for RsaKeypair {
     type Error = Error;
 
@@ -256,7 +249,6 @@ impl TryFrom<&rsa::RsaPrivateKey> for RsaKeypair {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl<D> TryFrom<&RsaKeypair> for pkcs1v15::SigningKey<D>
 where
     D: Digest + AssociatedOid,

--- a/ssh-key/src/private/sk.rs
+++ b/ssh-key/src/private/sk.rs
@@ -9,7 +9,6 @@ use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 /// Security Key (FIDO/U2F) ECDSA/NIST P-256 private key as specified in
 /// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
 #[cfg(all(feature = "alloc", feature = "ecdsa"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "ecdsa"))))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct SkEcdsaSha2NistP256 {
     /// Public key.
@@ -83,7 +82,6 @@ impl Encode for SkEcdsaSha2NistP256 {
 /// Security Key (FIDO/U2F) Ed25519 private key as specified in
 /// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct SkEd25519 {
     /// Public key.

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -87,7 +87,6 @@ impl PublicKey {
     ///
     /// On `no_std` platforms, use `PublicKey::from(key_data)` instead.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn new(key_data: KeyData, comment: impl Into<String>) -> Self {
         Self {
             key_data,
@@ -141,14 +140,12 @@ impl PublicKey {
     /// Encode an OpenSSH-formatted public key, allocating a [`String`] for
     /// the result.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_openssh(&self) -> Result<String> {
         SshFormat::encode_string(self.algorithm().as_str(), &self.key_data, self.comment())
     }
 
     /// Serialize SSH public key as raw bytes.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         let mut public_key_bytes = Vec::new();
         self.key_data.encode(&mut public_key_bytes)?;
@@ -169,7 +166,6 @@ impl PublicKey {
     ///
     /// [PROTOCOL.sshsig]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.sshsig?annotate=HEAD
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn verify(&self, namespace: &str, msg: &[u8], signature: &SshSig) -> Result<()> {
         if self.key_data() != signature.public_key() {
             return Err(Error::PublicKey);
@@ -184,7 +180,6 @@ impl PublicKey {
 
     /// Read public key from an OpenSSH-formatted file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn read_openssh_file(path: &Path) -> Result<Self> {
         let input = fs::read_to_string(path)?;
         Self::from_openssh(&input)
@@ -192,7 +187,6 @@ impl PublicKey {
 
     /// Write public key as an OpenSSH-formatted file.
     #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn write_openssh_file(&self, path: &Path) -> Result<()> {
         let encoded = self.to_openssh()?;
         fs::write(path, encoded.as_bytes())?;
@@ -230,7 +224,6 @@ impl PublicKey {
 
     /// Set the comment on the key.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn set_comment(&mut self, comment: impl Into<String>) {
         self.comment = comment.into();
     }
@@ -275,7 +268,6 @@ impl From<&PublicKey> for KeyData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<DsaPublicKey> for PublicKey {
     fn from(public_key: DsaPublicKey) -> PublicKey {
         KeyData::from(public_key).into()
@@ -283,7 +275,6 @@ impl From<DsaPublicKey> for PublicKey {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<EcdsaPublicKey> for PublicKey {
     fn from(public_key: EcdsaPublicKey) -> PublicKey {
         KeyData::from(public_key).into()
@@ -297,7 +288,6 @@ impl From<Ed25519PublicKey> for PublicKey {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<RsaPublicKey> for PublicKey {
     fn from(public_key: RsaPublicKey) -> PublicKey {
         KeyData::from(public_key).into()
@@ -305,7 +295,6 @@ impl From<RsaPublicKey> for PublicKey {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<SkEcdsaSha2NistP256> for PublicKey {
     fn from(public_key: SkEcdsaSha2NistP256) -> PublicKey {
         KeyData::from(public_key).into()
@@ -334,7 +323,6 @@ impl ToString for PublicKey {
 }
 
 #[cfg(all(feature = "alloc", feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "serde"))))]
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
     where
@@ -351,7 +339,6 @@ impl<'de> Deserialize<'de> for PublicKey {
 }
 
 #[cfg(all(feature = "alloc", feature = "serde"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "alloc", feature = "serde"))))]
 impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -6,7 +6,6 @@ use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 /// Digital Signature Algorithm (DSA) public key.
 ///
 /// Described in [FIPS 186-4 § 4.1](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct DsaPublicKey {
     /// Prime modulus.
@@ -57,7 +56,6 @@ impl Encode for DsaPublicKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<DsaPublicKey> for dsa::VerifyingKey {
     type Error = Error;
 
@@ -67,7 +65,6 @@ impl TryFrom<DsaPublicKey> for dsa::VerifyingKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<&DsaPublicKey> for dsa::VerifyingKey {
     type Error = Error;
 
@@ -84,7 +81,6 @@ impl TryFrom<&DsaPublicKey> for dsa::VerifyingKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<dsa::VerifyingKey> for DsaPublicKey {
     type Error = Error;
 
@@ -94,7 +90,6 @@ impl TryFrom<dsa::VerifyingKey> for DsaPublicKey {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl TryFrom<&dsa::VerifyingKey> for DsaPublicKey {
     type Error = Error;
 

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -20,7 +20,6 @@ pub type EcdsaNistP521PublicKey = sec1::EncodedPoint<U66>;
 /// `sec1` feature of this crate is enabled (which it is by default).
 ///
 /// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum EcdsaPublicKey {
     /// NIST P-256 ECDSA public key.
@@ -159,7 +158,6 @@ impl fmt::UpperHex for EcdsaPublicKey {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
     type Error = Error;
 
@@ -169,7 +167,6 @@ impl TryFrom<EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl TryFrom<EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
     type Error = Error;
 
@@ -179,7 +176,6 @@ impl TryFrom<EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<&EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
     type Error = Error;
 
@@ -194,7 +190,6 @@ impl TryFrom<&EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl TryFrom<&EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
     type Error = Error;
 
@@ -209,7 +204,6 @@ impl TryFrom<&EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl From<p256::ecdsa::VerifyingKey> for EcdsaPublicKey {
     fn from(key: p256::ecdsa::VerifyingKey) -> EcdsaPublicKey {
         EcdsaPublicKey::from(&key)
@@ -217,7 +211,6 @@ impl From<p256::ecdsa::VerifyingKey> for EcdsaPublicKey {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl From<&p256::ecdsa::VerifyingKey> for EcdsaPublicKey {
     fn from(key: &p256::ecdsa::VerifyingKey) -> EcdsaPublicKey {
         EcdsaPublicKey::NistP256(key.to_encoded_point(false))
@@ -225,7 +218,6 @@ impl From<&p256::ecdsa::VerifyingKey> for EcdsaPublicKey {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl From<p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
     fn from(key: p384::ecdsa::VerifyingKey) -> EcdsaPublicKey {
         EcdsaPublicKey::from(&key)
@@ -233,7 +225,6 @@ impl From<p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl From<&p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
     fn from(key: &p384::ecdsa::VerifyingKey) -> EcdsaPublicKey {
         EcdsaPublicKey::NistP384(key.to_encoded_point(false))

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -78,7 +78,6 @@ impl fmt::UpperHex for Ed25519PublicKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl TryFrom<Ed25519PublicKey> for ed25519_dalek::VerifyingKey {
     type Error = Error;
 
@@ -88,7 +87,6 @@ impl TryFrom<Ed25519PublicKey> for ed25519_dalek::VerifyingKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl TryFrom<&Ed25519PublicKey> for ed25519_dalek::VerifyingKey {
     type Error = Error;
 
@@ -98,7 +96,6 @@ impl TryFrom<&Ed25519PublicKey> for ed25519_dalek::VerifyingKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<ed25519_dalek::VerifyingKey> for Ed25519PublicKey {
     fn from(key: ed25519_dalek::VerifyingKey) -> Ed25519PublicKey {
         Ed25519PublicKey::from(&key)
@@ -106,7 +103,6 @@ impl From<ed25519_dalek::VerifyingKey> for Ed25519PublicKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl From<&ed25519_dalek::VerifyingKey> for Ed25519PublicKey {
     fn from(key: &ed25519_dalek::VerifyingKey) -> Ed25519PublicKey {
         Ed25519PublicKey(key.to_bytes())

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -16,12 +16,10 @@ use super::{EcdsaPublicKey, SkEcdsaSha2NistP256};
 pub enum KeyData {
     /// Digital Signature Algorithm (DSA) public key data.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Dsa(DsaPublicKey),
 
     /// Elliptic Curve Digital Signature Algorithm (ECDSA) public key data.
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     Ecdsa(EcdsaPublicKey),
 
     /// Ed25519 public key data.
@@ -29,14 +27,12 @@ pub enum KeyData {
 
     /// RSA public key data.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     Rsa(RsaPublicKey),
 
     /// Security Key (FIDO/U2F) using ECDSA/NIST P-256 as specified in [PROTOCOL.u2f].
     ///
     /// [PROTOCOL.u2f]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     SkEcdsaSha2NistP256(SkEcdsaSha2NistP256),
 
     /// Security Key (FIDO/U2F) using Ed25519 as specified in [PROTOCOL.u2f].
@@ -64,7 +60,6 @@ impl KeyData {
 
     /// Get DSA public key if this key is the correct type.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn dsa(&self) -> Option<&DsaPublicKey> {
         match self {
             Self::Dsa(key) => Some(key),
@@ -74,7 +69,6 @@ impl KeyData {
 
     /// Get ECDSA public key if this key is the correct type.
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn ecdsa(&self) -> Option<&EcdsaPublicKey> {
         match self {
             Self::Ecdsa(key) => Some(key),
@@ -100,7 +94,6 @@ impl KeyData {
 
     /// Get RSA public key if this key is the correct type.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn rsa(&self) -> Option<&RsaPublicKey> {
         match self {
             Self::Rsa(key) => Some(key),
@@ -110,7 +103,6 @@ impl KeyData {
 
     /// Get FIDO/U2F ECDSA/NIST P-256 public key if this key is the correct type.
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn sk_ecdsa_p256(&self) -> Option<&SkEcdsaSha2NistP256> {
         match self {
             Self::SkEcdsaSha2NistP256(sk) => Some(sk),
@@ -128,14 +120,12 @@ impl KeyData {
 
     /// Is this key a DSA key?
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn is_dsa(&self) -> bool {
         matches!(self, Self::Dsa(_))
     }
 
     /// Is this key an ECDSA key?
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn is_ecdsa(&self) -> bool {
         matches!(self, Self::Ecdsa(_))
     }
@@ -147,14 +137,12 @@ impl KeyData {
 
     /// Is this key an RSA key?
     #[cfg(feature = "alloc")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn is_rsa(&self) -> bool {
         matches!(self, Self::Rsa(_))
     }
 
     /// Is this key a FIDO/U2F ECDSA/NIST P-256 key?
     #[cfg(feature = "ecdsa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub fn is_sk_ecdsa_p256(&self) -> bool {
         matches!(self, Self::SkEcdsaSha2NistP256(_))
     }
@@ -248,7 +236,6 @@ impl Encode for KeyData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<DsaPublicKey> for KeyData {
     fn from(public_key: DsaPublicKey) -> KeyData {
         Self::Dsa(public_key)
@@ -256,7 +243,6 @@ impl From<DsaPublicKey> for KeyData {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<EcdsaPublicKey> for KeyData {
     fn from(public_key: EcdsaPublicKey) -> KeyData {
         Self::Ecdsa(public_key)
@@ -270,7 +256,6 @@ impl From<Ed25519PublicKey> for KeyData {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl From<RsaPublicKey> for KeyData {
     fn from(public_key: RsaPublicKey) -> KeyData {
         Self::Rsa(public_key)
@@ -278,7 +263,6 @@ impl From<RsaPublicKey> for KeyData {
 }
 
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<SkEcdsaSha2NistP256> for KeyData {
     fn from(public_key: SkEcdsaSha2NistP256) -> KeyData {
         Self::SkEcdsaSha2NistP256(public_key)

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -13,7 +13,6 @@ use {
 /// RSA public key.
 ///
 /// Described in [RFC4253 § 6.6](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6).
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct RsaPublicKey {
     /// RSA public exponent.
@@ -53,7 +52,6 @@ impl Encode for RsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<RsaPublicKey> for rsa::RsaPublicKey {
     type Error = Error;
 
@@ -63,7 +61,6 @@ impl TryFrom<RsaPublicKey> for rsa::RsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<&RsaPublicKey> for rsa::RsaPublicKey {
     type Error = Error;
 
@@ -83,7 +80,6 @@ impl TryFrom<&RsaPublicKey> for rsa::RsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<rsa::RsaPublicKey> for RsaPublicKey {
     type Error = Error;
 
@@ -93,7 +89,6 @@ impl TryFrom<rsa::RsaPublicKey> for RsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl TryFrom<&rsa::RsaPublicKey> for RsaPublicKey {
     type Error = Error;
 
@@ -106,7 +101,6 @@ impl TryFrom<&rsa::RsaPublicKey> for RsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl<D> TryFrom<&RsaPublicKey> for pkcs1v15::VerifyingKey<D>
 where
     D: Digest + AssociatedOid,

--- a/ssh-key/src/public/sk.rs
+++ b/ssh-key/src/public/sk.rs
@@ -18,7 +18,6 @@ const DEFAULT_APPLICATION_STRING: &str = "ssh:";
 /// Security Key (FIDO/U2F) ECDSA/NIST P-256 public key as specified in
 /// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
 #[cfg(feature = "ecdsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct SkEcdsaSha2NistP256 {
     /// Elliptic curve point representing a public key.

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -82,7 +82,6 @@ where
 /// [RFC8032]: https://datatracker.ietf.org/doc/html/rfc8032
 /// [RFC8332]: https://datatracker.ietf.org/doc/html/rfc8332
 #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub struct Signature {
     /// Signature algorithm.
     algorithm: Algorithm,
@@ -317,7 +316,6 @@ impl Verifier<Signature> for public::KeyData {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl Signer<Signature> for DsaKeypair {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         let signature = dsa::SigningKey::try_from(self)?
@@ -332,7 +330,6 @@ impl Signer<Signature> for DsaKeypair {
 }
 
 #[cfg(feature = "dsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dsa")))]
 impl Verifier<Signature> for DsaPublicKey {
     fn verify(&self, message: &[u8], signature: &Signature) -> signature::Result<()> {
         match signature.algorithm {
@@ -349,7 +346,6 @@ impl Verifier<Signature> for DsaPublicKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl TryFrom<Signature> for ed25519_dalek::Signature {
     type Error = Error;
 
@@ -359,7 +355,6 @@ impl TryFrom<Signature> for ed25519_dalek::Signature {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl TryFrom<&Signature> for ed25519_dalek::Signature {
     type Error = Error;
 
@@ -374,7 +369,6 @@ impl TryFrom<&Signature> for ed25519_dalek::Signature {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl Signer<Signature> for Ed25519Keypair {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         let signature = ed25519_dalek::SigningKey::try_from(self)?.sign(message);
@@ -387,7 +381,6 @@ impl Signer<Signature> for Ed25519Keypair {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl Verifier<Signature> for Ed25519PublicKey {
     fn verify(&self, message: &[u8], signature: &Signature) -> signature::Result<()> {
         let signature = ed25519_dalek::Signature::try_from(signature)?;
@@ -396,7 +389,6 @@ impl Verifier<Signature> for Ed25519PublicKey {
 }
 
 #[cfg(feature = "ed25519")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 impl Verifier<Signature> for public::SkEd25519 {
     fn verify(&self, message: &[u8], signature: &Signature) -> signature::Result<()> {
         let signature_len = signature
@@ -420,7 +412,6 @@ impl Verifier<Signature> for public::SkEd25519 {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<p256::ecdsa::Signature> for Signature {
     type Error = Error;
 
@@ -430,7 +421,6 @@ impl TryFrom<p256::ecdsa::Signature> for Signature {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl TryFrom<p384::ecdsa::Signature> for Signature {
     type Error = Error;
 
@@ -440,7 +430,6 @@ impl TryFrom<p384::ecdsa::Signature> for Signature {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<&p256::ecdsa::Signature> for Signature {
     type Error = Error;
 
@@ -463,7 +452,6 @@ impl TryFrom<&p256::ecdsa::Signature> for Signature {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl TryFrom<&p384::ecdsa::Signature> for Signature {
     type Error = Error;
 
@@ -486,7 +474,6 @@ impl TryFrom<&p384::ecdsa::Signature> for Signature {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<Signature> for p256::ecdsa::Signature {
     type Error = Error;
 
@@ -496,7 +483,6 @@ impl TryFrom<Signature> for p256::ecdsa::Signature {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl TryFrom<Signature> for p384::ecdsa::Signature {
     type Error = Error;
 
@@ -506,7 +492,6 @@ impl TryFrom<Signature> for p384::ecdsa::Signature {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl TryFrom<&Signature> for p256::ecdsa::Signature {
     type Error = Error;
 
@@ -537,7 +522,6 @@ impl TryFrom<&Signature> for p256::ecdsa::Signature {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl TryFrom<&Signature> for p384::ecdsa::Signature {
     type Error = Error;
 
@@ -568,7 +552,6 @@ impl TryFrom<&Signature> for p384::ecdsa::Signature {
 }
 
 #[cfg(any(feature = "p256", feature = "p384"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "p256", feature = "p384"))))]
 impl Signer<Signature> for EcdsaKeypair {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         match self {
@@ -582,7 +565,6 @@ impl Signer<Signature> for EcdsaKeypair {
 }
 
 #[cfg(feature = "p256")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p256")))]
 impl Signer<Signature> for EcdsaPrivateKey<32> {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         let signing_key = p256::ecdsa::SigningKey::from_slice(self.as_ref())?;
@@ -592,7 +574,6 @@ impl Signer<Signature> for EcdsaPrivateKey<32> {
 }
 
 #[cfg(feature = "p384")]
-#[cfg_attr(docsrs, doc(cfg(feature = "p384")))]
 impl Signer<Signature> for EcdsaPrivateKey<48> {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         let signing_key = p384::ecdsa::SigningKey::from_slice(self.as_ref())?;
@@ -602,7 +583,6 @@ impl Signer<Signature> for EcdsaPrivateKey<48> {
 }
 
 #[cfg(any(feature = "p256", feature = "p384"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "p256", feature = "p384"))))]
 impl Verifier<Signature> for EcdsaPublicKey {
     fn verify(&self, message: &[u8], signature: &Signature) -> signature::Result<()> {
         match signature.algorithm {
@@ -628,7 +608,6 @@ impl Verifier<Signature> for EcdsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl Signer<Signature> for RsaKeypair {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
         let data = rsa::pkcs1v15::SigningKey::<Sha512>::try_from(self)?
@@ -645,7 +624,6 @@ impl Signer<Signature> for RsaKeypair {
 }
 
 #[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 impl Verifier<Signature> for RsaPublicKey {
     fn verify(&self, message: &[u8], signature: &Signature) -> signature::Result<()> {
         match signature.algorithm {


### PR DESCRIPTION
Automatically generate feature-specific annotations for documentation rather than relying on manual ones