### PR TITLE
ssh-key: rename `MPInt` => `Mpint`

### DIFF
--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -177,7 +177,7 @@ pub use sha2;
 pub use crate::{
     certificate::Certificate,
     known_hosts::KnownHosts,
-    mpint::MPInt,
+    mpint::Mpint,
     signature::{Signature, SigningKey},
     sshsig::SshSig,
 };

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -39,12 +39,12 @@ use zeroize::Zeroizing;
 /// |-1234            | `00 00 00 02 ed cc`
 /// | -deadbeef       | `00 00 00 05 ff 21 52 41 11`
 #[derive(Clone, PartialOrd, Ord)]
-pub struct MPInt {
+pub struct Mpint {
     /// Inner big endian-serialized integer value
     inner: Vec<u8>,
 }
 
-impl MPInt {
+impl Mpint {
     /// Create a new multiple precision integer from the given
     /// big endian-encoded byte slice.
     ///
@@ -74,7 +74,7 @@ impl MPInt {
     /// Get the big integer data encoded as big endian bytes.
     ///
     /// This slice will contain a leading zero if the value is positive but the
-    /// MSB is also set. Use [`MPInt::as_positive_bytes`] to ensure the number
+    /// MSB is also set. Use [`Mpint::as_positive_bytes`] to ensure the number
     /// is positive and strip the leading zero byte if it exists.
     pub fn as_bytes(&self) -> &[u8] {
         &self.inner
@@ -94,27 +94,27 @@ impl MPInt {
     }
 }
 
-impl AsRef<[u8]> for MPInt {
+impl AsRef<[u8]> for Mpint {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl ConstantTimeEq for MPInt {
+impl ConstantTimeEq for Mpint {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.as_ref().ct_eq(other.as_ref())
     }
 }
 
-impl Eq for MPInt {}
+impl Eq for Mpint {}
 
-impl PartialEq for MPInt {
+impl PartialEq for Mpint {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
     }
 }
 
-impl Decode for MPInt {
+impl Decode for Mpint {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
@@ -122,7 +122,7 @@ impl Decode for MPInt {
     }
 }
 
-impl Encode for MPInt {
+impl Encode for Mpint {
     type Error = Error;
 
     fn encoded_len(&self) -> Result<usize> {
@@ -135,7 +135,7 @@ impl Encode for MPInt {
     }
 }
 
-impl TryFrom<&[u8]> for MPInt {
+impl TryFrom<&[u8]> for Mpint {
     type Error = Error;
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
@@ -143,7 +143,7 @@ impl TryFrom<&[u8]> for MPInt {
     }
 }
 
-impl TryFrom<Vec<u8>> for MPInt {
+impl TryFrom<Vec<u8>> for Mpint {
     type Error = Error;
 
     fn try_from(bytes: Vec<u8>) -> Result<Self> {
@@ -157,25 +157,25 @@ impl TryFrom<Vec<u8>> for MPInt {
     }
 }
 
-impl Zeroize for MPInt {
+impl Zeroize for Mpint {
     fn zeroize(&mut self) {
         self.inner.zeroize();
     }
 }
 
-impl fmt::Debug for MPInt {
+impl fmt::Debug for Mpint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "MPInt({self:X})")
+        write!(f, "Mpint({self:X})")
     }
 }
 
-impl fmt::Display for MPInt {
+impl fmt::Display for Mpint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:X}")
     }
 }
 
-impl fmt::LowerHex for MPInt {
+impl fmt::LowerHex for Mpint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_bytes() {
             write!(f, "{byte:02x}")?;
@@ -184,7 +184,7 @@ impl fmt::LowerHex for MPInt {
     }
 }
 
-impl fmt::UpperHex for MPInt {
+impl fmt::UpperHex for Mpint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.as_bytes() {
             write!(f, "{byte:02X}")?;
@@ -194,38 +194,38 @@ impl fmt::UpperHex for MPInt {
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-impl TryFrom<bigint::BigUint> for MPInt {
+impl TryFrom<bigint::BigUint> for Mpint {
     type Error = Error;
 
-    fn try_from(uint: bigint::BigUint) -> Result<MPInt> {
-        MPInt::try_from(&uint)
+    fn try_from(uint: bigint::BigUint) -> Result<Mpint> {
+        Mpint::try_from(&uint)
     }
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-impl TryFrom<&bigint::BigUint> for MPInt {
+impl TryFrom<&bigint::BigUint> for Mpint {
     type Error = Error;
 
-    fn try_from(uint: &bigint::BigUint) -> Result<MPInt> {
+    fn try_from(uint: &bigint::BigUint) -> Result<Mpint> {
         let bytes = Zeroizing::new(uint.to_bytes_be());
-        MPInt::from_positive_bytes(bytes.as_slice())
+        Mpint::from_positive_bytes(bytes.as_slice())
     }
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-impl TryFrom<MPInt> for bigint::BigUint {
+impl TryFrom<Mpint> for bigint::BigUint {
     type Error = Error;
 
-    fn try_from(mpint: MPInt) -> Result<bigint::BigUint> {
+    fn try_from(mpint: Mpint) -> Result<bigint::BigUint> {
         bigint::BigUint::try_from(&mpint)
     }
 }
 
 #[cfg(any(feature = "dsa", feature = "rsa"))]
-impl TryFrom<&MPInt> for bigint::BigUint {
+impl TryFrom<&Mpint> for bigint::BigUint {
     type Error = Error;
 
-    fn try_from(mpint: &MPInt) -> Result<bigint::BigUint> {
+    fn try_from(mpint: &Mpint) -> Result<bigint::BigUint> {
         mpint
             .as_positive_bytes()
             .map(bigint::BigUint::from_bytes_be)
@@ -235,30 +235,30 @@ impl TryFrom<&MPInt> for bigint::BigUint {
 
 #[cfg(test)]
 mod tests {
-    use super::MPInt;
+    use super::Mpint;
     use hex_literal::hex;
 
     #[test]
     fn decode_0() {
-        let n = MPInt::from_bytes(b"").unwrap();
+        let n = Mpint::from_bytes(b"").unwrap();
         assert_eq!(b"", n.as_bytes())
     }
 
     #[test]
     fn reject_extra_leading_zeroes() {
-        assert!(MPInt::from_bytes(&hex!("00")).is_err());
-        assert!(MPInt::from_bytes(&hex!("00 00")).is_err());
-        assert!(MPInt::from_bytes(&hex!("00 01")).is_err());
+        assert!(Mpint::from_bytes(&hex!("00")).is_err());
+        assert!(Mpint::from_bytes(&hex!("00 00")).is_err());
+        assert!(Mpint::from_bytes(&hex!("00 01")).is_err());
     }
 
     #[test]
     fn decode_9a378f9b2e332a7() {
-        assert!(MPInt::from_bytes(&hex!("09 a3 78 f9 b2 e3 32 a7")).is_ok());
+        assert!(Mpint::from_bytes(&hex!("09 a3 78 f9 b2 e3 32 a7")).is_ok());
     }
 
     #[test]
     fn decode_80() {
-        let n = MPInt::from_bytes(&hex!("00 80")).unwrap();
+        let n = Mpint::from_bytes(&hex!("00 80")).unwrap();
 
         // Leading zero stripped
         assert_eq!(&hex!("80"), n.as_positive_bytes().unwrap())
@@ -267,14 +267,14 @@ mod tests {
     // TODO(tarcieri): drop support for negative numbers?
     #[test]
     fn decode_neg_1234() {
-        let n = MPInt::from_bytes(&hex!("ed cc")).unwrap();
+        let n = Mpint::from_bytes(&hex!("ed cc")).unwrap();
         assert!(n.as_positive_bytes().is_none());
     }
 
     // TODO(tarcieri): drop support for negative numbers?
     #[test]
     fn decode_neg_deadbeef() {
-        let n = MPInt::from_bytes(&hex!("ff 21 52 41 11")).unwrap();
+        let n = Mpint::from_bytes(&hex!("ff 21 52 41 11")).unwrap();
         assert!(n.as_positive_bytes().is_none());
     }
 }

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -1,6 +1,6 @@
 //! Digital Signature Algorithm (DSA) private keys.
 
-use crate::{public::DsaPublicKey, Error, MPInt, Result};
+use crate::{public::DsaPublicKey, Error, Mpint, Result};
 use core::fmt;
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 use subtle::{Choice, ConstantTimeEq};
@@ -18,7 +18,7 @@ use rand_core::CryptoRngCore;
 #[derive(Clone)]
 pub struct DsaPrivateKey {
     /// Integer representing a DSA private key.
-    inner: MPInt,
+    inner: Mpint,
 }
 
 impl DsaPrivateKey {
@@ -27,8 +27,8 @@ impl DsaPrivateKey {
         self.inner.as_bytes()
     }
 
-    /// Get the inner [`MPInt`].
-    pub fn as_mpint(&self) -> &MPInt {
+    /// Get the inner [`Mpint`].
+    pub fn as_mpint(&self) -> &Mpint {
         &self.inner
     }
 }
@@ -58,7 +58,7 @@ impl Decode for DsaPrivateKey {
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
         Ok(Self {
-            inner: MPInt::decode(reader)?,
+            inner: Mpint::decode(reader)?,
         })
     }
 }

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -1,6 +1,6 @@
 //! Rivest–Shamir–Adleman (RSA) private keys.
 
-use crate::{public::RsaPublicKey, Error, MPInt, Result};
+use crate::{public::RsaPublicKey, Error, Mpint, Result};
 use core::fmt;
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 use subtle::{Choice, ConstantTimeEq};
@@ -17,16 +17,16 @@ use {
 #[derive(Clone)]
 pub struct RsaPrivateKey {
     /// RSA private exponent.
-    pub d: MPInt,
+    pub d: Mpint,
 
     /// CRT coefficient: `(inverse of q) mod p`.
-    pub iqmp: MPInt,
+    pub iqmp: Mpint,
 
     /// First prime factor of `n`.
-    pub p: MPInt,
+    pub p: Mpint,
 
     /// Second prime factor of `n`.
-    pub q: MPInt,
+    pub q: Mpint,
 }
 
 impl ConstantTimeEq for RsaPrivateKey {
@@ -50,10 +50,10 @@ impl Decode for RsaPrivateKey {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        let d = MPInt::decode(reader)?;
-        let iqmp = MPInt::decode(reader)?;
-        let p = MPInt::decode(reader)?;
-        let q = MPInt::decode(reader)?;
+        let d = Mpint::decode(reader)?;
+        let iqmp = Mpint::decode(reader)?;
+        let p = Mpint::decode(reader)?;
+        let q = Mpint::decode(reader)?;
         Ok(Self { d, iqmp, p, q })
     }
 }
@@ -133,8 +133,8 @@ impl Decode for RsaKeypair {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        let n = MPInt::decode(reader)?;
-        let e = MPInt::decode(reader)?;
+        let n = Mpint::decode(reader)?;
+        let e = Mpint::decode(reader)?;
         let public = RsaPublicKey { n, e };
         let private = RsaPrivateKey::decode(reader)?;
         Ok(RsaKeypair { public, private })

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -1,6 +1,6 @@
 //! Digital Signature Algorithm (DSA) public keys.
 
-use crate::{Error, MPInt, Result};
+use crate::{Error, Mpint, Result};
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 
 /// Digital Signature Algorithm (DSA) public key.
@@ -9,27 +9,27 @@ use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct DsaPublicKey {
     /// Prime modulus.
-    pub p: MPInt,
+    pub p: Mpint,
 
     /// Prime divisor of `p - 1`.
-    pub q: MPInt,
+    pub q: Mpint,
 
     /// Generator of a subgroup of order `q` in the multiplicative group
     /// `GF(p)`, such that `1 < g < p`.
-    pub g: MPInt,
+    pub g: Mpint,
 
     /// The public key, where `y = gˣ mod p`.
-    pub y: MPInt,
+    pub y: Mpint,
 }
 
 impl Decode for DsaPublicKey {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        let p = MPInt::decode(reader)?;
-        let q = MPInt::decode(reader)?;
-        let g = MPInt::decode(reader)?;
-        let y = MPInt::decode(reader)?;
+        let p = Mpint::decode(reader)?;
+        let q = Mpint::decode(reader)?;
+        let g = Mpint::decode(reader)?;
+        let y = Mpint::decode(reader)?;
         Ok(Self { p, q, g, y })
     }
 }

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -1,6 +1,6 @@
 //! Rivest–Shamir–Adleman (RSA) public keys.
 
-use crate::{Error, MPInt, Result};
+use crate::{Error, Mpint, Result};
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 
 #[cfg(feature = "rsa")]
@@ -16,10 +16,10 @@ use {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct RsaPublicKey {
     /// RSA public exponent.
-    pub e: MPInt,
+    pub e: Mpint,
 
     /// RSA modulus.
-    pub n: MPInt,
+    pub n: Mpint,
 }
 
 impl RsaPublicKey {
@@ -32,8 +32,8 @@ impl Decode for RsaPublicKey {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        let e = MPInt::decode(reader)?;
-        let n = MPInt::decode(reader)?;
+        let e = Mpint::decode(reader)?;
+        let n = Mpint::decode(reader)?;
         Ok(Self { e, n })
     }
 }

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -1,6 +1,6 @@
 //! Signatures (e.g. CA signatures over SSH certificates)
 
-use crate::{private, public, Algorithm, Error, MPInt, PrivateKey, PublicKey, Result};
+use crate::{private, public, Algorithm, Error, Mpint, PrivateKey, PublicKey, Result};
 use alloc::vec::Vec;
 use core::fmt;
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
@@ -108,7 +108,7 @@ impl Signature {
                 let reader = &mut data.as_slice();
 
                 for _ in 0..2 {
-                    let component = MPInt::decode(reader)?;
+                    let component = Mpint::decode(reader)?;
 
                     if component.as_positive_bytes().ok_or(Error::Crypto)?.len()
                         != curve.field_size()
@@ -437,8 +437,8 @@ impl TryFrom<&p256::ecdsa::Signature> for Signature {
         #[allow(clippy::integer_arithmetic)]
         let mut data = Vec::with_capacity(32 * 2 + 4 * 2 + 2);
 
-        MPInt::from_positive_bytes(&r)?.encode(&mut data)?;
-        MPInt::from_positive_bytes(&s)?.encode(&mut data)?;
+        Mpint::from_positive_bytes(&r)?.encode(&mut data)?;
+        Mpint::from_positive_bytes(&s)?.encode(&mut data)?;
 
         Ok(Signature {
             algorithm: Algorithm::Ecdsa {
@@ -459,8 +459,8 @@ impl TryFrom<&p384::ecdsa::Signature> for Signature {
         #[allow(clippy::integer_arithmetic)]
         let mut data = Vec::with_capacity(48 * 2 + 4 * 2 + 2);
 
-        MPInt::from_positive_bytes(&r)?.encode(&mut data)?;
-        MPInt::from_positive_bytes(&s)?.encode(&mut data)?;
+        Mpint::from_positive_bytes(&r)?.encode(&mut data)?;
+        Mpint::from_positive_bytes(&s)?.encode(&mut data)?;
 
         Ok(Signature {
             algorithm: Algorithm::Ecdsa {
@@ -501,8 +501,8 @@ impl TryFrom<&Signature> for p256::ecdsa::Signature {
                 curve: EcdsaCurve::NistP256,
             } => {
                 let reader = &mut signature.as_bytes();
-                let r = MPInt::decode(reader)?;
-                let s = MPInt::decode(reader)?;
+                let r = Mpint::decode(reader)?;
+                let s = Mpint::decode(reader)?;
 
                 match (r.as_positive_bytes(), s.as_positive_bytes()) {
                     (Some(r), Some(s)) if r.len() == FIELD_SIZE && s.len() == FIELD_SIZE => {
@@ -531,8 +531,8 @@ impl TryFrom<&Signature> for p384::ecdsa::Signature {
                 curve: EcdsaCurve::NistP256,
             } => {
                 let reader = &mut signature.as_bytes();
-                let r = MPInt::decode(reader)?;
-                let s = MPInt::decode(reader)?;
+                let r = Mpint::decode(reader)?;
+                let s = Mpint::decode(reader)?;
 
                 match (r.as_positive_bytes(), s.as_positive_bytes()) {
                     (Some(r), Some(s)) if r.len() == FIELD_SIZE && s.len() == FIELD_SIZE => {


### PR DESCRIPTION
From https://rust-lang.github.io/api-guidelines/naming.html

> In UpperCamelCase, acronyms and contractions of compound words count
> as one word: use Uuid rather than UUID, Usize rather than USize or
> Stdin rather than StdIn.

Based on that guidance, this renames the `Mpint` type accordingly.