### PR TITLE
ssh-key: split `AlgorithmUnknown` and `AlgorithmUnsupported`

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -148,7 +148,7 @@ impl Algorithm {
             SSH_RSA => Ok(Algorithm::Rsa { hash: None }),
             SK_ECDSA_SHA2_P256 => Ok(Algorithm::SkEcdsaSha2NistP256),
             SK_SSH_ED25519 => Ok(Algorithm::SkEd25519),
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 
@@ -185,7 +185,7 @@ impl Algorithm {
             CERT_RSA => Ok(Algorithm::Rsa { hash: None }),
             CERT_SK_ECDSA_SHA2_P256 => Ok(Algorithm::SkEcdsaSha2NistP256),
             CERT_SK_SSH_ED25519 => Ok(Algorithm::SkEd25519),
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 
@@ -250,6 +250,12 @@ impl Algorithm {
     pub fn is_rsa(self) -> bool {
         matches!(self, Algorithm::Rsa { .. })
     }
+
+    /// Return an error indicating this algorithm is unsupported.
+    #[allow(dead_code)]
+    pub(crate) fn unsupported_error(self) -> Error {
+        Error::AlgorithmUnsupported { algorithm: self }
+    }
 }
 
 impl AsRef<str> for Algorithm {
@@ -308,7 +314,7 @@ impl EcdsaCurve {
             "nistp256" => Ok(EcdsaCurve::NistP256),
             "nistp384" => Ok(EcdsaCurve::NistP384),
             "nistp521" => Ok(EcdsaCurve::NistP521),
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 
@@ -378,7 +384,7 @@ impl HashAlg {
         match id {
             SHA256 => Ok(HashAlg::Sha256),
             SHA512 => Ok(HashAlg::Sha512),
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 
@@ -458,7 +464,7 @@ impl KdfAlg {
         match kdfname {
             NONE => Ok(Self::None),
             BCRYPT => Ok(Self::Bcrypt),
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -177,7 +177,7 @@ impl Certificate {
 
         // Verify that the algorithm in the Base64-encoded data matches the text
         if encapsulation.algorithm_id != cert.algorithm().as_certificate_str() {
-            return Err(Error::Algorithm);
+            return Err(Error::AlgorithmUnknown);
         }
 
         cert.comment = encapsulation.comment.to_owned();

--- a/ssh-key/src/cipher.rs
+++ b/ssh-key/src/cipher.rs
@@ -58,7 +58,7 @@ impl Cipher {
             "none" => Ok(Self::None),
             AES256_CTR => Ok(Self::Aes256Ctr),
             AES256_GCM => Ok(Self::Aes256Gcm),
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types
 
+use crate::Algorithm;
 use core::fmt;
 
 #[cfg(feature = "alloc")]
@@ -12,8 +13,22 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
-    /// Algorithm-related errors.
-    Algorithm,
+    /// Unknown algorithm.
+    ///
+    /// This is returned when an algorithm is completely unknown to this crate.
+    AlgorithmUnknown,
+
+    /// Unsupported algorithm.
+    ///
+    /// This is typically returned when an algorithm is recognized, but the
+    /// relevant crate features to support it haven't been enabled.
+    ///
+    /// It may also be returned in the event an algorithm is inappropriate for
+    /// a given usage pattern or context.
+    AlgorithmUnsupported {
+        /// Algorithm identifier.
+        algorithm: Algorithm,
+    },
 
     /// Certificate field is invalid or already set.
     #[cfg(feature = "alloc")]
@@ -70,7 +85,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Algorithm => write!(f, "unknown or unsupported algorithm"),
+            Error::AlgorithmUnknown => write!(f, "unknown algorithm"),
+            Error::AlgorithmUnsupported { algorithm } => {
+                write!(f, "unsupported algorithm: {algorithm}")
+            }
             #[cfg(feature = "alloc")]
             Error::CertificateFieldInvalid(field) => {
                 write!(f, "certificate field invalid: {field}")

--- a/ssh-key/src/fingerprint.rs
+++ b/ssh-key/src/fingerprint.rs
@@ -179,13 +179,13 @@ impl FromStr for Fingerprint {
     type Err = Error;
 
     fn from_str(id: &str) -> Result<Self> {
-        let (alg_str, base64) = id.split_once(':').ok_or(Error::Algorithm)?;
+        let (alg_str, base64) = id.split_once(':').ok_or(Error::AlgorithmUnknown)?;
 
         // Fingerprints use a special upper-case hash algorithm encoding.
         let algorithm = match alg_str {
             "SHA256" => HashAlg::Sha256,
             "SHA512" => HashAlg::Sha512,
-            _ => return Err(Error::Algorithm),
+            _ => return Err(Error::AlgorithmUnknown),
         };
 
         // Buffer size is the largest digest size of of any supported hash function

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -47,7 +47,7 @@ impl Kdf {
         match algorithm {
             KdfAlg::None => {
                 // Disallow explicit initialization with a `none` algorithm
-                Err(Error::Algorithm)
+                Err(Error::AlgorithmUnknown)
             }
             KdfAlg::Bcrypt => Ok(Kdf::Bcrypt {
                 salt,
@@ -129,12 +129,12 @@ impl Decode for Kdf {
                 if usize::decode(reader)? == 0 {
                     Ok(Self::None)
                 } else {
-                    Err(Error::Algorithm)
+                    Err(Error::AlgorithmUnknown)
                 }
             }
             KdfAlg::Bcrypt => {
                 #[cfg(not(feature = "alloc"))]
-                return Err(Error::Algorithm);
+                return Err(Error::AlgorithmUnknown);
 
                 #[cfg(feature = "alloc")]
                 reader.read_prefixed(|reader| {

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -446,7 +446,7 @@ impl PrivateKey {
     /// Generate a random key which uses the given algorithm.
     ///
     /// # Returns
-    /// - `Error::Algorithm` if the algorithm is unsupported.
+    /// - `Error::AlgorithmUnknown` if the algorithm is unsupported.
     #[cfg(feature = "rand_core")]
     #[allow(unreachable_code, unused_variables)]
     pub fn random(rng: &mut impl CryptoRngCore, algorithm: Algorithm) -> Result<Self> {
@@ -462,7 +462,7 @@ impl PrivateKey {
             Algorithm::Rsa { .. } => {
                 KeypairData::from(RsaKeypair::random(rng, DEFAULT_RSA_KEY_SIZE)?)
             }
-            _ => return Err(Error::Algorithm),
+            _ => return Err(Error::AlgorithmUnknown),
         };
         let public_key = public::KeyData::try_from(&key_data)?;
 

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -198,7 +198,7 @@ impl EcdsaKeypair {
                     public: public.into(),
                 })
             }
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 

--- a/ssh-key/src/private/keypair.rs
+++ b/ssh-key/src/private/keypair.rs
@@ -267,7 +267,7 @@ impl Decode for KeypairData {
             #[cfg(feature = "ecdsa")]
             Algorithm::Ecdsa { curve } => match EcdsaKeypair::decode(reader)? {
                 keypair if keypair.curve() == curve => Ok(Self::Ecdsa(keypair)),
-                _ => Err(Error::Algorithm),
+                _ => Err(Error::AlgorithmUnknown),
             },
             Algorithm::Ed25519 => Ed25519Keypair::decode(reader).map(Self::Ed25519),
             #[cfg(feature = "alloc")]
@@ -279,7 +279,7 @@ impl Decode for KeypairData {
             #[cfg(feature = "alloc")]
             Algorithm::SkEd25519 => SkEd25519::decode(reader).map(Self::SkEd25519),
             #[allow(unreachable_patterns)]
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 }

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -108,7 +108,7 @@ impl PublicKey {
 
         // Verify that the algorithm in the Base64-encoded data matches the text
         if encapsulation.algorithm_id != key_data.algorithm().as_str() {
-            return Err(Error::Algorithm);
+            return Err(Error::AlgorithmUnknown);
         }
 
         let public_key = Self {

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -51,7 +51,7 @@ impl EcdsaPublicKey {
                         rest.len()
                     }
                     sec1::point::Tag::Uncompressed => rest.len() / 2,
-                    _ => return Err(Error::Algorithm),
+                    _ => return Err(Error::AlgorithmUnknown),
                 };
 
                 match point_size {
@@ -109,7 +109,7 @@ impl Decode for EcdsaPublicKey {
         if key.curve() == curve {
             Ok(key)
         } else {
-            Err(Error::Algorithm)
+            Err(Error::AlgorithmUnknown)
         }
     }
 }
@@ -184,7 +184,7 @@ impl TryFrom<&EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
             EcdsaPublicKey::NistP256(key) => {
                 p256::ecdsa::VerifyingKey::from_encoded_point(key).map_err(|_| Error::Crypto)
             }
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 }
@@ -198,7 +198,7 @@ impl TryFrom<&EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
             EcdsaPublicKey::NistP384(key) => {
                 p384::ecdsa::VerifyingKey::from_encoded_point(key).map_err(|_| Error::Crypto)
             }
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 }

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -160,7 +160,7 @@ impl KeyData {
             #[cfg(feature = "ecdsa")]
             Algorithm::Ecdsa { curve } => match EcdsaPublicKey::decode(reader)? {
                 key if key.curve() == curve => Ok(Self::Ecdsa(key)),
-                _ => Err(Error::Algorithm),
+                _ => Err(Error::AlgorithmUnknown),
             },
             Algorithm::Ed25519 => Ed25519PublicKey::decode(reader).map(Self::Ed25519),
             #[cfg(feature = "alloc")]
@@ -171,7 +171,7 @@ impl KeyData {
             }
             Algorithm::SkEd25519 => SkEd25519::decode(reader).map(Self::SkEd25519),
             #[allow(unreachable_patterns)]
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -361,7 +361,7 @@ impl TryFrom<&Signature> for ed25519_dalek::Signature {
             Algorithm::Ed25519 | Algorithm::SkEd25519 => {
                 Ok(ed25519_dalek::Signature::try_from(signature.as_bytes())?)
             }
-            _ => Err(Error::Algorithm),
+            _ => Err(Error::AlgorithmUnknown),
         }
     }
 }
@@ -514,7 +514,7 @@ impl TryFrom<&Signature> for p256::ecdsa::Signature {
                     _ => Err(Error::Crypto),
                 }
             }
-            _ => Err(Error::Algorithm),
+            _ => Err(signature.algorithm.unsupported_error()),
         }
     }
 }
@@ -544,7 +544,7 @@ impl TryFrom<&Signature> for p384::ecdsa::Signature {
                     _ => Err(Error::Crypto),
                 }
             }
-            _ => Err(Error::Algorithm),
+            _ => Err(signature.algorithm.unsupported_error()),
         }
     }
 }

--- a/ssh-key/src/sshsig.rs
+++ b/ssh-key/src/sshsig.rs
@@ -100,12 +100,12 @@ impl SshSig {
         }
 
         if signing_key.public_key().is_sk_ed25519() {
-            return Err(Error::Algorithm);
+            return Err(Algorithm::SkEd25519.unsupported_error());
         }
 
         #[cfg(feature = "ecdsa")]
         if signing_key.public_key().is_sk_ecdsa_p256() {
-            return Err(Error::Algorithm);
+            return Err(Algorithm::SkEcdsaSha2NistP256.unsupported_error());
         }
 
         let signed_data = Self::signed_data(namespace, hash_alg, msg)?;


### PR DESCRIPTION
Splits the `Error` variants for unknown vs unsupported algorithms, propagating the `Algorithm` for the latter.

This helps identify which algorithm was unsupported, which can be used to inform what crate features need to be enabled.