### PR TITLE
ssh-key: propagate `Error` through `signature::Error`

### DIFF
--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -145,15 +145,35 @@ impl From<encoding::pem::Error> for Error {
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl From<signature::Error> for Error {
     fn from(_: signature::Error) -> Error {
         Error::Crypto
     }
 }
 
+#[cfg(feature = "std")]
+impl From<signature::Error> for Error {
+    fn from(err: signature::Error) -> Error {
+        use std::error::Error as _;
+
+        err.source()
+            .and_then(|source| source.downcast_ref().copied())
+            .unwrap_or(Error::Crypto)
+    }
+}
+
+#[cfg(not(feature = "std"))]
 impl From<Error> for signature::Error {
     fn from(_: Error) -> signature::Error {
         signature::Error::new()
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Error> for signature::Error {
+    fn from(err: Error) -> signature::Error {
+        signature::Error::from_source(err)
     }
 }
 

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -282,7 +282,7 @@ impl Signer<Signature> for private::KeypairData {
             Self::Ed25519(keypair) => keypair.try_sign(message),
             #[cfg(feature = "rsa")]
             Self::Rsa(keypair) => keypair.try_sign(message),
-            _ => Err(signature::Error::new()),
+            _ => Err(self.algorithm()?.unsupported_error().into()),
         }
     }
 }
@@ -308,7 +308,7 @@ impl Verifier<Signature> for public::KeyData {
             #[cfg(feature = "rsa")]
             Self::Rsa(pk) => pk.verify(message, signature),
             #[allow(unreachable_patterns)]
-            _ => Err(signature::Error::new()),
+            _ => Err(self.algorithm().unsupported_error().into()),
         }
     }
 }
@@ -338,7 +338,7 @@ impl Verifier<Signature> for DsaPublicKey {
                     .verify_digest(Sha1::new_with_prefix(message), &signature)
                     .map_err(|_| signature::Error::new())
             }
-            _ => Err(signature::Error::new()),
+            _ => Err(signature.algorithm().unsupported_error().into()),
         }
     }
 }
@@ -557,7 +557,7 @@ impl Signer<Signature> for EcdsaKeypair {
             Self::NistP256 { private, .. } => private.try_sign(message),
             #[cfg(feature = "p384")]
             Self::NistP384 { private, .. } => private.try_sign(message),
-            _ => Err(signature::Error::new()),
+            _ => Err(self.algorithm().unsupported_error().into()),
         }
     }
 }
@@ -591,6 +591,7 @@ impl Verifier<Signature> for EcdsaPublicKey {
                     let signature = p256::ecdsa::Signature::try_from(signature)?;
                     verifying_key.verify(message, &signature)
                 }
+
                 #[cfg(feature = "p384")]
                 EcdsaCurve::NistP384 => {
                     let verifying_key = p384::ecdsa::VerifyingKey::try_from(self)?;
@@ -598,9 +599,9 @@ impl Verifier<Signature> for EcdsaPublicKey {
                     verifying_key.verify(message, &signature)
                 }
 
-                _ => Err(signature::Error::new()),
+                _ => Err(signature.algorithm().unsupported_error().into()),
             },
-            _ => Err(signature::Error::new()),
+            _ => Err(signature.algorithm().unsupported_error().into()),
         }
     }
 }
@@ -637,7 +638,7 @@ impl Verifier<Signature> for RsaPublicKey {
                         .map_err(|_| signature::Error::new()),
                 }
             }
-            _ => Err(signature::Error::new()),
+            _ => Err(signature.algorithm().unsupported_error().into()),
         }
     }
 }


### PR DESCRIPTION
When the `std` feature is enabled, supports fully round tripping `ssh_key::Error` through `signature::Error` using
`signature::Error::from_source`.

This prevents important context from being lost, like if the error is due to an unsupported algorithm.