### PR TITLE
ssh-key: add `crypto` feature

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -69,7 +69,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,getrandom,std
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features crypto,default,getrandom,std --release
 
   test:
     runs-on: ubuntu-latest
@@ -84,9 +84,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --exclude-features aes-gcm,default,encryption,getrandom,std
-      - run: cargo test --features aes-gcm
-      - run: cargo test --features encryption
-      - run: cargo test --features getrandom
-      - run: cargo test --features std
-      - run: cargo test --all-features
+      - run: cargo hack test --feature-powerset --exclude-features aes-gcm,crypto,default,encryption,getrandom,std --release
+      - run: cargo test --release
+      - run: cargo test --release --features aes-gcm
+      - run: cargo test --release --features crypto
+      - run: cargo test --release --features encryption
+      - run: cargo test --release --features getrandom
+      - run: cargo test --release --features std
+      - run: cargo test --all-features # debug build
+      - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
+ "sha2",
  "signature",
  "subtle",
  "zeroize",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -34,7 +34,7 @@ ed25519-dalek = { version = "=2.0.0-pre.0", optional = true, default-features = 
 p256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
-rsa = { version = "=0.9.0-pre.0", optional = true, default-features = false }
+rsa = { version = "=0.9.0-pre.0", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.7", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha1 = { version = "0.10", optional = true, default-features = false }
@@ -62,12 +62,15 @@ std = [
 ]
 
 aes-gcm = ["dep:aes-gcm", "encryption"]
+crypto = ["aes-gcm", "ed25519", "p256", "p384", "rsa"] # NOTE: `dsa` is obsolete/weak
 dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand_core"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [ "alloc", "dep:aes", "dep:bcrypt-pbkdf", "dep:ctr", "rand_core"]
 getrandom = ["rand_core/getrandom"]
-rsa = ["dep:bigint", "dep:rsa", "alloc", "rand_core", "sha2/oid"]
+p256 = ["dep:p256", "ecdsa"]
+p384 = ["dep:p384", "ecdsa"]
+rsa = ["dep:bigint", "dep:rsa", "alloc", "rand_core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -61,7 +61,7 @@ respective SSH key algorithm.
   - [ ] [RFC4716] public keys
   - [ ] SEC1
 
-## Supported algorithms
+### Supported Signature Algorithms
 
 | Name                                 | Decode | Encode | Cert | Keygen | Sign | Verify | Feature   | `no_std` |
 |--------------------------------------|--------|--------|------|--------|------|--------|-----------|----------|
@@ -74,7 +74,13 @@ respective SSH key algorithm.
 | `sk‑ecdsa‑sha2‑nistp256@openssh.com` | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ⛔️     | ⛔        | `alloc`  |
 | `sk‑ssh‑ed25519@openssh.com`         | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ⛔️     | ⛔        | `alloc`  |
 
-Note: the "Feature" section lists the name of `ssh-key` crate features which can
+By default *no algorithms are enabled* and you will get an
+`Error::AlgorithmUnsupported` error if you try to use them.
+
+Enable the `crypto` feature or the "Feature" for specific algorithms in the
+chart above (e.g. `p256`, `rsa`) in order to use cryptographic functionality.
+
+The "Feature" column lists the name of `ssh-key` crate features which can
 be enabled to provide full support for the "Keygen", "Sign", and "Verify"
 functionality for a particular SSH key algorithm.
 

--- a/ssh-key/tests/sshsig.rs
+++ b/ssh-key/tests/sshsig.rs
@@ -5,7 +5,12 @@
 use hex_literal::hex;
 use ssh_key::{Algorithm, HashAlg, LineEnding, PublicKey, SshSig};
 
-#[cfg(any(feature = "dsa", feature = "ed25519", feature = "rsa"))]
+#[cfg(any(
+    feature = "dsa",
+    feature = "ed25519",
+    feature = "p256",
+    feature = "rsa"
+))]
 use ssh_key::PrivateKey;
 
 #[cfg(feature = "ed25519")]


### PR DESCRIPTION
Adds a feature which enables cryptographic support without requiring users to enable specific algorithms.

It enables all available digital signature algorithms except for `dsa`, which is obsolete/weak.

It also enables the `aes-gcm` feature and transitively enables the `encryption` feature with support for encrypted private keys.

Also adds some documentation improvements.