### PR TITLE
Replace unmaintained actions-rs/cargo action in CI workflow

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -43,7 +43,4 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/RustCrypto/SSH/actions/runs/4472783875:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.

_(Note: The switch from `actions-rs/toolchain` to `dtolnay/rust-toolchain` has already been made in <https://github.com/RustCrypto/SSH/pull/70>, so there is no need to replace it anymore.)_