### PR TITLE
ssh-key: bump `rsa` to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.0-pre.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db0998ad35adcaca498b7358992e088ee16cc783fe6fb899da203e113a63e5"
+checksum = "3dd2017d3e6d67384f301f8b06fbf4567afc576430a61624d845eb04d2b30a72"
 dependencies = [
  "byteorder",
  "const-oid",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -34,7 +34,7 @@ ed25519-dalek = { version = "=2.0.0-rc.2", optional = true, default-features = f
 p256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
-rsa = { version = "=0.9.0-pre.2", optional = true, default-features = false, features = ["sha2"] }
+rsa = { version = "0.9", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.7", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha1 = { version = "0.10", optional = true, default-features = false }

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -9,7 +9,10 @@ use zeroize::Zeroize;
 #[cfg(feature = "rsa")]
 use {
     rand_core::CryptoRngCore,
-    rsa::{pkcs1v15, PublicKeyParts},
+    rsa::{
+        pkcs1v15,
+        traits::{PrivateKeyParts, PublicKeyParts},
+    },
     sha2::{digest::const_oid::AssociatedOid, Digest},
 };
 

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -6,7 +6,7 @@ use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 #[cfg(feature = "rsa")]
 use {
     crate::private::RsaKeypair,
-    rsa::{pkcs1v15, PublicKeyParts},
+    rsa::{pkcs1v15, traits::PublicKeyParts},
     sha2::{digest::const_oid::AssociatedOid, Digest},
 };
 


### PR DESCRIPTION
Release notes: https://github.com/RustCrypto/RSA/pull/318