### PR TITLE
ssh-encoding: remove `Encoding::Error`; add `LabelError`

### DIFF
--- a/ssh-encoding/src/error.rs
+++ b/ssh-encoding/src/error.rs
@@ -1,12 +1,13 @@
 //! Error types
 
+use crate::LabelError;
 use core::fmt;
 
 /// Result type with `ssh-encoding` crate's [`Error`] as the error type.
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// Base64-related errors.
@@ -15,6 +16,9 @@ pub enum Error {
 
     /// Character encoding-related errors.
     CharacterEncoding,
+
+    /// Invalid label.
+    Label(LabelError),
 
     /// Invalid length.
     Length,
@@ -39,6 +43,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "base64")]
             Error::Base64(err) => write!(f, "Base64 encoding error: {err}"),
             Error::CharacterEncoding => write!(f, "character encoding invalid"),
+            Error::Label(err) => write!(f, "{}", err),
             Error::Length => write!(f, "length invalid"),
             Error::Overflow => write!(f, "internal overflow error"),
             #[cfg(feature = "pem")]
@@ -48,6 +53,12 @@ impl fmt::Display for Error {
                 "unexpected trailing data at end of message ({remaining} bytes)",
             ),
         }
+    }
+}
+
+impl From<LabelError> for Error {
+    fn from(err: LabelError) -> Error {
+        Error::Label(err)
     }
 }
 

--- a/ssh-encoding/src/label.rs
+++ b/ssh-encoding/src/label.rs
@@ -1,7 +1,10 @@
 //! Convenience trait for decoding/encoding string labels.
 
-use crate::{Decode, Encode, Reader, Writer};
-use core::str::FromStr;
+use crate::{Decode, Encode, Error, Reader, Writer};
+use core::{fmt, str::FromStr};
+
+#[cfg(feature = "alloc")]
+use alloc::string::String;
 
 /// Maximum size of any algorithm name/identifier.
 const MAX_LABEL_SIZE: usize = 48;
@@ -9,28 +12,71 @@ const MAX_LABEL_SIZE: usize = 48;
 /// Labels for e.g. cryptographic algorithms.
 ///
 /// Receives a blanket impl of [`Decode`] and [`Encode`].
-pub trait Label: AsRef<str> + FromStr<Err = Self::Error> {
-    /// Type returned in the event of an encoding error.
-    type Error: From<crate::Error>;
-}
+pub trait Label: AsRef<str> + FromStr<Err = LabelError> {}
 
 impl<T: Label> Decode for T {
-    type Error = T::Error;
+    type Error = Error;
 
-    fn decode(reader: &mut impl Reader) -> Result<Self, T::Error> {
+    fn decode(reader: &mut impl Reader) -> Result<Self, Error> {
         let mut buf = [0u8; MAX_LABEL_SIZE];
-        reader.read_string(buf.as_mut())?.parse()
+        Ok(reader.read_string(buf.as_mut())?.parse()?)
     }
 }
 
 impl<T: Label> Encode for T {
-    type Error = T::Error;
-
-    fn encoded_len(&self) -> Result<usize, T::Error> {
-        Ok(self.as_ref().encoded_len()?)
+    fn encoded_len(&self) -> Result<usize, Error> {
+        self.as_ref().encoded_len()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<(), T::Error> {
-        Ok(self.as_ref().encode(writer)?)
+    fn encode(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        self.as_ref().encode(writer)
     }
 }
+
+/// Errors related to labels.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct LabelError {
+    /// The label that was considered invalid.
+    #[cfg(feature = "alloc")]
+    label: String,
+}
+
+impl LabelError {
+    /// Create a new [`LabelError`] for the given invalid label.
+    #[cfg_attr(not(feature = "alloc"), allow(unused_variables))]
+    pub fn new(label: &str) -> Self {
+        Self {
+            #[cfg(feature = "alloc")]
+            label: label.into(),
+        }
+    }
+
+    /// The invalid label string (if available).
+    #[inline]
+    pub fn label(&self) -> &str {
+        #[cfg(not(feature = "alloc"))]
+        {
+            ""
+        }
+        #[cfg(feature = "alloc")]
+        {
+            &self.label
+        }
+    }
+}
+
+impl fmt::Display for LabelError {
+    #[cfg(not(feature = "alloc"))]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("invalid label")
+    }
+
+    #[cfg(feature = "alloc")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid label: '{}'", self.label)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for LabelError {}

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::{
     decode::Decode,
     encode::Encode,
     error::{Error, Result},
-    label::Label,
+    label::{Label, LabelError},
     reader::{NestedReader, Reader},
     writer::Writer,
 };

--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use core::{fmt, str};
-use encoding::Label;
+use encoding::{Label, LabelError};
 
 #[cfg(feature = "alloc")]
 use {
@@ -128,29 +128,7 @@ impl Algorithm {
     /// - `sk-ecdsa-sha2-nistp256@openssh.com` (FIDO/U2F key)
     /// - `sk-ssh-ed25519@openssh.com` (FIDO/U2F key)
     pub fn new(id: &str) -> Result<Self> {
-        match id {
-            SSH_DSA => Ok(Algorithm::Dsa),
-            ECDSA_SHA2_P256 => Ok(Algorithm::Ecdsa {
-                curve: EcdsaCurve::NistP256,
-            }),
-            ECDSA_SHA2_P384 => Ok(Algorithm::Ecdsa {
-                curve: EcdsaCurve::NistP384,
-            }),
-            ECDSA_SHA2_P521 => Ok(Algorithm::Ecdsa {
-                curve: EcdsaCurve::NistP521,
-            }),
-            RSA_SHA2_256 => Ok(Algorithm::Rsa {
-                hash: Some(HashAlg::Sha256),
-            }),
-            RSA_SHA2_512 => Ok(Algorithm::Rsa {
-                hash: Some(HashAlg::Sha512),
-            }),
-            SSH_ED25519 => Ok(Algorithm::Ed25519),
-            SSH_RSA => Ok(Algorithm::Rsa { hash: None }),
-            SK_ECDSA_SHA2_P256 => Ok(Algorithm::SkEcdsaSha2NistP256),
-            SK_SSH_ED25519 => Ok(Algorithm::SkEd25519),
-            _ => Err(Error::AlgorithmUnknown),
-        }
+        Ok(id.parse()?)
     }
 
     /// Decode algorithm from the given string identifier as used by
@@ -265,9 +243,7 @@ impl AsRef<str> for Algorithm {
     }
 }
 
-impl Label for Algorithm {
-    type Error = Error;
-}
+impl Label for Algorithm {}
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -276,10 +252,32 @@ impl fmt::Display for Algorithm {
 }
 
 impl str::FromStr for Algorithm {
-    type Err = Error;
+    type Err = LabelError;
 
-    fn from_str(id: &str) -> Result<Self> {
-        Self::new(id)
+    fn from_str(id: &str) -> core::result::Result<Self, LabelError> {
+        match id {
+            SSH_DSA => Ok(Algorithm::Dsa),
+            ECDSA_SHA2_P256 => Ok(Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP256,
+            }),
+            ECDSA_SHA2_P384 => Ok(Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP384,
+            }),
+            ECDSA_SHA2_P521 => Ok(Algorithm::Ecdsa {
+                curve: EcdsaCurve::NistP521,
+            }),
+            RSA_SHA2_256 => Ok(Algorithm::Rsa {
+                hash: Some(HashAlg::Sha256),
+            }),
+            RSA_SHA2_512 => Ok(Algorithm::Rsa {
+                hash: Some(HashAlg::Sha512),
+            }),
+            SSH_ED25519 => Ok(Algorithm::Ed25519),
+            SSH_RSA => Ok(Algorithm::Rsa { hash: None }),
+            SK_ECDSA_SHA2_P256 => Ok(Algorithm::SkEcdsaSha2NistP256),
+            SK_SSH_ED25519 => Ok(Algorithm::SkEd25519),
+            _ => Err(LabelError::new(id)),
+        }
     }
 }
 
@@ -305,12 +303,7 @@ impl EcdsaCurve {
     /// - `nistp384`
     /// - `nistp521`
     pub fn new(id: &str) -> Result<Self> {
-        match id {
-            "nistp256" => Ok(EcdsaCurve::NistP256),
-            "nistp384" => Ok(EcdsaCurve::NistP384),
-            "nistp521" => Ok(EcdsaCurve::NistP521),
-            _ => Err(Error::AlgorithmUnknown),
-        }
+        Ok(id.parse()?)
     }
 
     /// Get the string identifier which corresponds to this ECDSA elliptic curve.
@@ -339,9 +332,7 @@ impl AsRef<str> for EcdsaCurve {
     }
 }
 
-impl Label for EcdsaCurve {
-    type Error = Error;
-}
+impl Label for EcdsaCurve {}
 
 impl fmt::Display for EcdsaCurve {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -350,10 +341,15 @@ impl fmt::Display for EcdsaCurve {
 }
 
 impl str::FromStr for EcdsaCurve {
-    type Err = Error;
+    type Err = LabelError;
 
-    fn from_str(id: &str) -> Result<Self> {
-        EcdsaCurve::new(id)
+    fn from_str(id: &str) -> core::result::Result<Self, LabelError> {
+        match id {
+            "nistp256" => Ok(EcdsaCurve::NistP256),
+            "nistp384" => Ok(EcdsaCurve::NistP384),
+            "nistp521" => Ok(EcdsaCurve::NistP521),
+            _ => Err(LabelError::new(id)),
+        }
     }
 }
 
@@ -377,11 +373,7 @@ impl HashAlg {
     /// - `sha256`
     /// - `sha512`
     pub fn new(id: &str) -> Result<Self> {
-        match id {
-            SHA256 => Ok(HashAlg::Sha256),
-            SHA512 => Ok(HashAlg::Sha512),
-            _ => Err(Error::AlgorithmUnknown),
-        }
+        Ok(id.parse()?)
     }
 
     /// Get the string identifier for this hash algorithm.
@@ -410,9 +402,7 @@ impl HashAlg {
     }
 }
 
-impl Label for HashAlg {
-    type Error = Error;
-}
+impl Label for HashAlg {}
 
 impl AsRef<str> for HashAlg {
     fn as_ref(&self) -> &str {
@@ -427,10 +417,14 @@ impl fmt::Display for HashAlg {
 }
 
 impl str::FromStr for HashAlg {
-    type Err = Error;
+    type Err = LabelError;
 
-    fn from_str(id: &str) -> Result<Self> {
-        HashAlg::new(id)
+    fn from_str(id: &str) -> core::result::Result<Self, LabelError> {
+        match id {
+            SHA256 => Ok(HashAlg::Sha256),
+            SHA512 => Ok(HashAlg::Sha512),
+            _ => Err(LabelError::new(id)),
+        }
     }
 }
 
@@ -452,11 +446,7 @@ impl KdfAlg {
     /// # Supported KDF names
     /// - `none`
     pub fn new(kdfname: &str) -> Result<Self> {
-        match kdfname {
-            NONE => Ok(Self::None),
-            BCRYPT => Ok(Self::Bcrypt),
-            _ => Err(Error::AlgorithmUnknown),
-        }
+        Ok(kdfname.parse()?)
     }
 
     /// Get the string identifier which corresponds to this algorithm.
@@ -473,9 +463,7 @@ impl KdfAlg {
     }
 }
 
-impl Label for KdfAlg {
-    type Error = Error;
-}
+impl Label for KdfAlg {}
 
 impl AsRef<str> for KdfAlg {
     fn as_ref(&self) -> &str {
@@ -490,9 +478,13 @@ impl fmt::Display for KdfAlg {
 }
 
 impl str::FromStr for KdfAlg {
-    type Err = Error;
+    type Err = LabelError;
 
-    fn from_str(id: &str) -> Result<Self> {
-        Self::new(id)
+    fn from_str(kdfname: &str) -> core::result::Result<Self, LabelError> {
+        match kdfname {
+            NONE => Ok(Self::None),
+            BCRYPT => Ok(Self::Bcrypt),
+            _ => Err(LabelError::new(kdfname)),
+        }
     }
 }

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -428,7 +428,7 @@ impl Certificate {
 
     /// Encode the portion of the certificate "to be signed" by the CA
     /// (or to be verified against an existing CA signature)
-    fn encode_tbs(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode_tbs(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.algorithm().as_certificate_str().encode(writer)?;
         self.nonce.encode(writer)?;
         self.public_key.encode_key_data(writer)?;
@@ -471,10 +471,8 @@ impl Decode for Certificate {
 }
 
 impl Encode for Certificate {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.algorithm().as_certificate_str().encoded_len()?,
             self.nonce.encoded_len()?,
             self.public_key.encoded_key_data_len()?,
@@ -490,10 +488,10 @@ impl Encode for Certificate {
             self.signature_key.encoded_len_prefixed()?,
             self.signature.encoded_len_prefixed()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.encode_tbs(writer)?;
         self.signature.encode_prefixed(writer)
     }

--- a/ssh-key/src/certificate/cert_type.rs
+++ b/ssh-key/src/certificate/cert_type.rs
@@ -41,13 +41,11 @@ impl Decode for CertType {
 }
 
 impl Encode for CertType {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
+    fn encoded_len(&self) -> encoding::Result<usize> {
         Ok(4)
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         u32::from(*self).encode(writer)?;
         Ok(())
     }

--- a/ssh-key/src/certificate/options_map.rs
+++ b/ssh-key/src/certificate/options_map.rs
@@ -62,9 +62,7 @@ impl Decode for OptionsMap {
 }
 
 impl Encode for OptionsMap {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
+    fn encoded_len(&self) -> encoding::Result<usize> {
         self.iter()
             .try_fold(4, |acc, (name, data)| {
                 [acc, 4, name.len(), 4, data.len()].checked_sum()
@@ -72,7 +70,7 @@ impl Encode for OptionsMap {
             .map_err(Into::into)
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.encoded_len()?
             .checked_sub(4)
             .ok_or(encoding::Error::Length)?

--- a/ssh-key/src/certificate/unix_time.rs
+++ b/ssh-key/src/certificate/unix_time.rs
@@ -74,13 +74,11 @@ impl Decode for UnixTime {
 }
 
 impl Encode for UnixTime {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok(self.secs.encoded_len()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        self.secs.encoded_len()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.secs.encode(writer)?;
         Ok(())
     }

--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -10,7 +10,7 @@ use crate::certificate;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
     /// Unknown algorithm.
@@ -133,6 +133,12 @@ impl From<encoding::Error> for Error {
     }
 }
 
+impl From<encoding::LabelError> for Error {
+    fn from(err: encoding::LabelError) -> Error {
+        Error::Encoding(err.into())
+    }
+}
+
 impl From<encoding::base64::Error> for Error {
     fn from(err: encoding::base64::Error) -> Error {
         Error::Encoding(err.into())
@@ -158,7 +164,7 @@ impl From<signature::Error> for Error {
         use std::error::Error as _;
 
         err.source()
-            .and_then(|source| source.downcast_ref().copied())
+            .and_then(|source| source.downcast_ref().cloned())
             .unwrap_or(Error::Crypto)
     }
 }

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -149,19 +149,17 @@ impl Decode for Kdf {
 }
 
 impl Encode for Kdf {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
+    fn encoded_len(&self) -> encoding::Result<usize> {
         let kdfopts_prefixed_len = match self {
             Self::None => 4,
             #[cfg(feature = "alloc")]
             Self::Bcrypt { salt, .. } => [12, salt.len()].checked_sum()?,
         };
 
-        Ok([self.algorithm().encoded_len()?, kdfopts_prefixed_len].checked_sum()?)
+        [self.algorithm().encoded_len()?, kdfopts_prefixed_len].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.algorithm().encode(writer)?;
 
         match self {

--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -123,13 +123,11 @@ impl Decode for Mpint {
 }
 
 impl Encode for Mpint {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([4, self.as_bytes().len()].checked_sum()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [4, self.as_bytes().len()].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.as_bytes().encode(writer)?;
         Ok(())
     }

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -64,13 +64,11 @@ impl Decode for DsaPrivateKey {
 }
 
 impl Encode for DsaPrivateKey {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
+    fn encoded_len(&self) -> encoding::Result<usize> {
         self.inner.encoded_len()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.inner.encode(writer)
     }
 }
@@ -174,13 +172,11 @@ impl Decode for DsaKeypair {
 }
 
 impl Encode for DsaKeypair {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([self.public.encoded_len()?, self.private.encoded_len()?].checked_sum()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [self.public.encoded_len()?, self.private.encoded_len()?].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.public.encode(writer)?;
         self.private.encode(writer)
     }

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -55,13 +55,11 @@ impl<const SIZE: usize> Decode for EcdsaPrivateKey<SIZE> {
 }
 
 impl<const SIZE: usize> Encode for EcdsaPrivateKey<SIZE> {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([4, self.needs_leading_zero().into(), SIZE].checked_sum()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [4, self.needs_leading_zero().into(), SIZE].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         [self.needs_leading_zero().into(), SIZE]
             .checked_sum()?
             .encode(writer)?;
@@ -288,9 +286,7 @@ impl Decode for EcdsaKeypair {
 }
 
 impl Encode for EcdsaKeypair {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
+    fn encoded_len(&self) -> encoding::Result<usize> {
         let public_len = EcdsaPublicKey::from(self).encoded_len()?;
 
         let private_len = match self {
@@ -299,10 +295,10 @@ impl Encode for EcdsaKeypair {
             Self::NistP521 { private, .. } => private.encoded_len()?,
         };
 
-        Ok([public_len, private_len].checked_sum()?)
+        [public_len, private_len].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         EcdsaPublicKey::from(self).encode(writer)?;
 
         match self {

--- a/ssh-key/src/private/ed25519.rs
+++ b/ssh-key/src/private/ed25519.rs
@@ -231,13 +231,11 @@ impl Decode for Ed25519Keypair {
 }
 
 impl Encode for Ed25519Keypair {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([4, self.public.encoded_len()?, Self::BYTE_SIZE].checked_sum()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [4, self.public.encoded_len()?, Self::BYTE_SIZE].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.public.encode(writer)?;
         Zeroizing::new(self.to_bytes()).as_ref().encode(writer)?;
         Ok(())

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -62,19 +62,17 @@ impl Decode for RsaPrivateKey {
 }
 
 impl Encode for RsaPrivateKey {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.d.encoded_len()?,
             self.iqmp.encoded_len()?,
             self.p.encoded_len()?,
             self.q.encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.d.encode(writer)?;
         self.iqmp.encode(writer)?;
         self.p.encode(writer)?;
@@ -145,18 +143,16 @@ impl Decode for RsaKeypair {
 }
 
 impl Encode for RsaKeypair {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.public.n.encoded_len()?,
             self.public.e.encoded_len()?,
             self.private.encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.public.n.encode(writer)?;
         self.public.e.encode(writer)?;
         self.private.encode(writer)

--- a/ssh-key/src/private/sk.rs
+++ b/ssh-key/src/private/sk.rs
@@ -58,19 +58,17 @@ impl Decode for SkEcdsaSha2NistP256 {
 
 #[cfg(feature = "ecdsa")]
 impl Encode for SkEcdsaSha2NistP256 {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.public.encoded_len()?,
             self.flags.encoded_len()?,
             self.key_handle.encoded_len()?,
             self.reserved.encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.public.encode(writer)?;
         self.flags.encode(writer)?;
         self.key_handle.encode(writer)?;
@@ -128,19 +126,17 @@ impl Decode for SkEd25519 {
 }
 
 impl Encode for SkEd25519 {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.public.encoded_len()?,
             self.flags.encoded_len()?,
             self.key_handle.encoded_len()?,
             self.reserved.encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.public.encode(writer)?;
         self.flags.encode(writer)?;
         self.key_handle.encode(writer)?;

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -35,19 +35,17 @@ impl Decode for DsaPublicKey {
 }
 
 impl Encode for DsaPublicKey {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.p.encoded_len()?,
             self.q.encoded_len()?,
             self.g.encoded_len()?,
             self.y.encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.p.encode(writer)?;
         self.q.encode(writer)?;
         self.g.encode(writer)?;

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -115,18 +115,16 @@ impl Decode for EcdsaPublicKey {
 }
 
 impl Encode for EcdsaPublicKey {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.curve().encoded_len()?,
             4, // uint32 length prefix
             self.as_ref().len(),
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.curve().encode(writer)?;
         self.as_ref().encode(writer)?;
         Ok(())

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -33,13 +33,11 @@ impl Decode for Ed25519PublicKey {
 }
 
 impl Encode for Ed25519PublicKey {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([4, Self::BYTE_SIZE].checked_sum()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [4, Self::BYTE_SIZE].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.0.encode(writer)?;
         Ok(())
     }

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -177,7 +177,7 @@ impl KeyData {
 
     /// Get the encoded length of this key data without a leading algorithm
     /// identifier.
-    pub(crate) fn encoded_key_data_len(&self) -> Result<usize> {
+    pub(crate) fn encoded_key_data_len(&self) -> encoding::Result<usize> {
         match self {
             #[cfg(feature = "alloc")]
             Self::Dsa(key) => key.encoded_len(),
@@ -193,7 +193,7 @@ impl KeyData {
     }
 
     /// Encode the key data without a leading algorithm identifier.
-    pub(crate) fn encode_key_data(&self, writer: &mut impl Writer) -> Result<()> {
+    pub(crate) fn encode_key_data(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         match self {
             #[cfg(feature = "alloc")]
             Self::Dsa(key) => key.encode(writer),
@@ -219,17 +219,15 @@ impl Decode for KeyData {
 }
 
 impl Encode for KeyData {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.algorithm().encoded_len()?,
             self.encoded_key_data_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.algorithm().encode(writer)?;
         self.encode_key_data(writer)
     }

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -39,13 +39,11 @@ impl Decode for RsaPublicKey {
 }
 
 impl Encode for RsaPublicKey {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([self.e.encoded_len()?, self.n.encoded_len()?].checked_sum()?)
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [self.e.encoded_len()?, self.n.encoded_len()?].checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.e.encode(writer)?;
         self.n.encode(writer)
     }

--- a/ssh-key/src/public/sk.rs
+++ b/ssh-key/src/public/sk.rs
@@ -75,18 +75,16 @@ impl Decode for SkEcdsaSha2NistP256 {
 
 #[cfg(feature = "ecdsa")]
 impl Encode for SkEcdsaSha2NistP256 {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             EcdsaCurve::NistP256.encoded_len()?,
             self.ec_point.as_bytes().encoded_len()?,
             self.application().encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         EcdsaCurve::NistP256.encode(writer)?;
         self.ec_point.as_bytes().encode(writer)?;
         self.application().encode(writer)?;
@@ -163,17 +161,15 @@ impl Decode for SkEd25519 {
 }
 
 impl Encode for SkEd25519 {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.public_key.encoded_len()?,
             self.application().encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.public_key.encode(writer)?;
         self.application().encode(writer)?;
         Ok(())

--- a/ssh-key/src/public/ssh_format.rs
+++ b/ssh-key/src/public/ssh_format.rs
@@ -12,7 +12,7 @@
 //! ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti user@example.com
 //! ```
 
-use crate::{Error, Result};
+use crate::Result;
 use core::str;
 use encoding::{Base64Writer, Encode};
 
@@ -60,7 +60,7 @@ impl<'a> SshFormat<'a> {
         out: &'o mut [u8],
     ) -> Result<&'o str>
     where
-        K: Encode<Error = Error>,
+        K: Encode,
     {
         let mut offset = 0;
         encode_str(out, &mut offset, algorithm_id)?;
@@ -86,7 +86,7 @@ impl<'a> SshFormat<'a> {
     #[cfg(feature = "alloc")]
     pub(crate) fn encode_string<K>(algorithm_id: &str, key: &K, comment: &str) -> Result<String>
     where
-        K: Encode<Error = Error>,
+        K: Encode,
     {
         let encoded_len = [
             2, // interstitial spaces

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -181,19 +181,17 @@ impl Decode for Signature {
 }
 
 impl Encode for Signature {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             self.algorithm().encoded_len()?,
             self.as_bytes().encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         if self.is_placeholder() {
-            return Err(encoding::Error::Length.into());
+            return Err(encoding::Error::Length);
         }
 
         self.algorithm().encode(writer)?;
@@ -782,7 +780,7 @@ mod tests {
         let mut writer = Vec::new();
         assert_eq!(
             placeholder.encode(&mut writer),
-            Err(encoding::Error::Length.into())
+            Err(encoding::Error::Length)
         );
     }
 }

--- a/ssh-key/src/sshsig.rs
+++ b/ssh-key/src/sshsig.rs
@@ -85,7 +85,7 @@ impl SshSig {
     /// -----BEGIN SSH SIGNATURE-----
     /// ```
     pub fn to_pem(&self, line_ending: LineEnding) -> Result<String> {
-        self.encode_pem_string(line_ending)
+        Ok(self.encode_pem_string(line_ending)?)
     }
 
     /// Sign the given message with the provided signing key.
@@ -254,10 +254,8 @@ impl Decode for SshSig {
 }
 
 impl Encode for SshSig {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             Self::MAGIC_PREAMBLE.len(),
             self.version.encoded_len()?,
             self.public_key.encoded_len_prefixed()?,
@@ -266,10 +264,10 @@ impl Encode for SshSig {
             self.hash_alg.encoded_len()?,
             self.signature.encoded_len_prefixed()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         writer.write(Self::MAGIC_PREAMBLE)?;
         self.version.encode(writer)?;
         self.public_key.encode_prefixed(writer)?;
@@ -317,21 +315,19 @@ impl<'a> SignedData<'a> {
     }
 }
 
-impl<'a> Encode for SignedData<'a> {
-    type Error = Error;
-
-    fn encoded_len(&self) -> Result<usize> {
-        Ok([
+impl Encode for SignedData<'_> {
+    fn encoded_len(&self) -> encoding::Result<usize> {
+        [
             SshSig::MAGIC_PREAMBLE.len(),
             self.namespace.encoded_len()?,
             self.reserved.encoded_len()?,
             self.hash_alg.encoded_len()?,
             self.hash.encoded_len()?,
         ]
-        .checked_sum()?)
+        .checked_sum()
     }
 
-    fn encode(&self, writer: &mut impl Writer) -> Result<()> {
+    fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         writer.write(SshSig::MAGIC_PREAMBLE)?;
         self.namespace.encode(writer)?;
         self.reserved.encode(writer)?;


### PR DESCRIPTION
Removes the associated `Encoding::Error` type as well as `Label::Error`, using `ssh_encoding::Error` as the type.

The rationale is error customization is primarily useful for decoding, not encoding. This change is a simplification.

Adds a `LabelError` type which captures the invalid label when the `alloc` feature has been enabled for display purposes. This is used as the error type for `FromStr` impls, so invalid labels can be propagated properly.