### PR TITLE
ssh-cipher: `Error` enum

### DIFF
--- a/ssh-cipher/src/chacha20poly1305.rs
+++ b/ssh-cipher/src/chacha20poly1305.rs
@@ -41,7 +41,7 @@ impl ChaCha20Poly1305 {
     pub fn new(key: &[u8], nonce: &[u8]) -> Result<Self> {
         #[allow(clippy::integer_arithmetic)]
         if key.len() != KEY_SIZE * 2 {
-            return Err(Error);
+            return Err(Error::KeySize);
         }
 
         // TODO(tarcieri): support for using both keys
@@ -52,7 +52,7 @@ impl ChaCha20Poly1305 {
             // For key encryption
             Nonce::default()
         } else {
-            Nonce::try_from(nonce).map_err(|_| Error)?
+            Nonce::try_from(nonce).map_err(|_| Error::IvSize)?
         };
 
         let mut cipher = ChaCha20::new(key, &nonce.into());
@@ -81,7 +81,7 @@ impl ChaCha20Poly1305 {
             self.cipher.apply_keystream(buffer);
             Ok(())
         } else {
-            Err(Error)
+            Err(Error::Crypto)
         }
     }
 }

--- a/ssh-cipher/src/error.rs
+++ b/ssh-cipher/src/error.rs
@@ -1,0 +1,42 @@
+//! Error types.
+
+use crate::Cipher;
+use core::fmt;
+
+/// Result type with `ssh-cipher` crate's [`Error`] as the error type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Error type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Cryptographic errors.
+    Crypto,
+
+    /// Invalid key size.
+    KeySize,
+
+    /// Invalid initialization vector / nonce size.
+    IvSize,
+
+    /// Invalid AEAD tag size.
+    TagSize,
+
+    /// Unsupported cipher.
+    UnsupportedCipher(Cipher),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Crypto => write!(f, "cryptographic error"),
+            Error::KeySize => write!(f, "invalid key size"),
+            Error::IvSize => write!(f, "invalid initialization vector size"),
+            Error::TagSize => write!(f, "invalid AEAD tag size"),
+            Error::UnsupportedCipher(cipher) => write!(f, "unsupported cipher: {}", cipher),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/ssh-encoding/src/error.rs
+++ b/ssh-encoding/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types
+//! Error types.
 
 use crate::LabelError;
 use core::fmt;


### PR DESCRIPTION
Uses an `Error::Crypto` variant as a replacement variant for opaque cryptographic errors.

Adds variants for invalid key/IV/tag sizes as well as unsupported ciphers (i.e. relevant crate features not enabled).