### PR TITLE
Corrected the docs to say public key

### DIFF
--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -210,7 +210,7 @@ impl PublicKey {
         &self.comment
     }
 
-    /// Private key data.
+    /// Public key data.
     pub fn key_data(&self) -> &KeyData {
         &self.key_data
     }


### PR DESCRIPTION
There was a copy and paste error in the docs for the function PublicKey::key_data, which said that it would return the private key. ( I hope this was a mistake and not an new attack against ssh keys)