### PR TITLE
ssh-encoding: `bytes` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +771,7 @@ name = "ssh-encoding"
 version = "0.2.0-pre.0"
 dependencies = [
  "base64ct",
+ "bytes",
  "hex-literal",
  "pem-rfc7468",
  "sha2",

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.60"
 
 [dependencies]
 base64 = { package = "base64ct", version = "1.4", optional = true }
+bytes = { version = "1", optional = true, default-features = false }
 pem = { package = "pem-rfc7468", version = "0.7", optional = true }
 sha2 = { version = "0.10", optional = true, default-features = false }
 
@@ -26,6 +27,7 @@ hex-literal = "0.4.1"
 alloc = ["base64?/alloc", "pem?/alloc"]
 std = ["alloc", "base64?/std", "pem?/std", "sha2?/std"]
 
+bytes = ["alloc", "dep:bytes"]
 pem = ["base64", "dep:pem"]
 
 [package.metadata.docs.rs]

--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -8,6 +8,9 @@ use crate::{reader::Reader, Error, Result};
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
+#[cfg(feature = "bytes")]
+use bytes::Bytes;
+
 #[cfg(feature = "pem")]
 use {crate::PEM_LINE_WIDTH, pem::PemLabel};
 
@@ -175,5 +178,21 @@ impl Decode for Vec<String> {
 
             Ok(entries)
         })
+    }
+}
+
+/// Decodes `Bytes` from `byte[n]` as described in [RFC4251 § 5]:
+///
+/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
+/// > data is sometimes represented as an array of bytes, written
+/// > `byte[n]`, where n is the number of bytes in the array.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+#[cfg(feature = "bytes")]
+impl Decode for Bytes {
+    type Error = Error;
+
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        Vec::<u8>::decode(reader).map(Into::into)
     }
 }

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -9,6 +9,9 @@ use core::str;
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
+#[cfg(feature = "bytes")]
+use bytes::Bytes;
+
 #[cfg(feature = "pem")]
 use {
     crate::PEM_LINE_WIDTH,
@@ -247,5 +250,16 @@ impl Encode for Vec<String> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Encode for Bytes {
+    fn encoded_len(&self) -> Result<usize, Error> {
+        self.as_ref().encoded_len()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        self.as_ref().encode(writer)
     }
 }


### PR DESCRIPTION
Adds (optional) support for decoding/encoding `bytes::Bytes` as `byte[n]`.