### PR TITLE
ssh-key: lazily compute `AlgorithmName::certificate_type`

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -9,7 +9,7 @@ use encoding::{Label, LabelError};
 
 #[cfg(feature = "alloc")]
 use {
-    alloc::vec::Vec,
+    alloc::{borrow::ToOwned, string::String, vec::Vec},
     sha2::{Digest, Sha256, Sha512},
 };
 
@@ -179,7 +179,7 @@ impl Algorithm {
             CERT_SK_ECDSA_SHA2_P256 => Ok(Algorithm::SkEcdsaSha2NistP256),
             CERT_SK_SSH_ED25519 => Ok(Algorithm::SkEd25519),
             #[cfg(feature = "alloc")]
-            _ => Ok(Algorithm::Other(AlgorithmName::from_certificate_str(id)?)),
+            _ => Ok(Algorithm::Other(AlgorithmName::from_certificate_type(id)?)),
             #[cfg(not(feature = "alloc"))]
             _ => Err(Error::AlgorithmUnknown),
         }
@@ -214,7 +214,8 @@ impl Algorithm {
     /// See [PROTOCOL.certkeys] for more information.
     ///
     /// [PROTOCOL.certkeys]: https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.certkeys?annotate=HEAD
-    pub fn as_certificate_str(&self) -> &str {
+    #[cfg(feature = "alloc")]
+    pub fn to_certificate_type(&self) -> String {
         match self {
             Algorithm::Dsa => CERT_DSA,
             Algorithm::Ecdsa { curve } => match curve {
@@ -226,9 +227,9 @@ impl Algorithm {
             Algorithm::Rsa { .. } => CERT_RSA,
             Algorithm::SkEcdsaSha2NistP256 => CERT_SK_ECDSA_SHA2_P256,
             Algorithm::SkEd25519 => CERT_SK_SSH_ED25519,
-            #[cfg(feature = "alloc")]
-            Algorithm::Other(algorithm) => algorithm.certificate_str(),
+            Algorithm::Other(algorithm) => return algorithm.certificate_type(),
         }
+        .to_owned()
     }
 
     /// Is the algorithm DSA?

--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -176,7 +176,7 @@ impl Certificate {
         let mut cert = Certificate::decode(&mut reader)?;
 
         // Verify that the algorithm in the Base64-encoded data matches the text
-        if encapsulation.algorithm_id != cert.algorithm().as_certificate_str() {
+        if encapsulation.algorithm_id != cert.algorithm().to_certificate_type() {
             return Err(Error::AlgorithmUnknown);
         }
 
@@ -193,7 +193,11 @@ impl Certificate {
 
     /// Encode OpenSSH certificate to a [`String`].
     pub fn to_openssh(&self) -> Result<String> {
-        SshFormat::encode_string(self.algorithm().as_certificate_str(), self, self.comment())
+        SshFormat::encode_string(
+            &self.algorithm().to_certificate_type(),
+            self,
+            self.comment(),
+        )
     }
 
     /// Serialize OpenSSH certificate as raw bytes.
@@ -429,7 +433,7 @@ impl Certificate {
     /// Encode the portion of the certificate "to be signed" by the CA
     /// (or to be verified against an existing CA signature)
     fn encode_tbs(&self, writer: &mut impl Writer) -> encoding::Result<()> {
-        self.algorithm().as_certificate_str().encode(writer)?;
+        self.algorithm().to_certificate_type().encode(writer)?;
         self.nonce.encode(writer)?;
         self.public_key.encode_key_data(writer)?;
         self.serial.encode(writer)?;
@@ -473,7 +477,7 @@ impl Decode for Certificate {
 impl Encode for Certificate {
     fn encoded_len(&self) -> encoding::Result<usize> {
         [
-            self.algorithm().as_certificate_str().encoded_len()?,
+            self.algorithm().to_certificate_type().encoded_len()?,
             self.nonce.encoded_len()?,
             self.public_key.encoded_key_data_len()?,
             self.serial.encoded_len()?,

--- a/ssh-key/tests/algorithm_name.rs
+++ b/ssh-key/tests/algorithm_name.rs
@@ -12,11 +12,11 @@ fn additional_algorithm_name() {
 
     let name = AlgorithmName::from_str(NAME).unwrap();
     assert_eq!(name.as_str(), NAME);
-    assert_eq!(name.certificate_str(), CERT_STR);
+    assert_eq!(name.certificate_type(), CERT_STR);
 
-    let name = AlgorithmName::from_certificate_str(CERT_STR).unwrap();
+    let name = AlgorithmName::from_certificate_type(CERT_STR).unwrap();
     assert_eq!(name.as_str(), NAME);
-    assert_eq!(name.certificate_str(), CERT_STR);
+    assert_eq!(name.certificate_type(), CERT_STR);
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn invalid_algorithm_name() {
 
     for name in INVALID_CERT_STRS {
         assert!(
-            AlgorithmName::from_certificate_str(&name).is_err(),
+            AlgorithmName::from_certificate_type(&name).is_err(),
             "{:?} should be an invalid certificate str",
             name
         );


### PR DESCRIPTION
Only computes the certificate algorithm identifier when needed as opposed to eagerly.