### PR TITLE
ssh-key: fix `certificate::Builder::new_with_validity_times`

### DIFF
--- a/ssh-key/src/certificate/builder.rs
+++ b/ssh-key/src/certificate/builder.rs
@@ -145,7 +145,7 @@ impl Builder {
         let valid_before =
             UnixTime::try_from(valid_before).map_err(|_| Field::ValidBefore.invalid_error())?;
 
-        Self::new(nonce, public_key, valid_before.into(), valid_after.into())
+        Self::new(nonce, public_key, valid_after.into(), valid_before.into())
     }
 
     /// Create a new certificate builder, generating a random nonce using the


### PR DESCRIPTION
It previously had the `valid_after` and `valid_before` arguments swapped, which would've caused errors with expected usage.

This commit adds a test that confirmed the certificate builder initializes successfully after swapping the arguments back.

Closes #142