### PR TITLE
ssh-key: have PublicKey and its parts implment Hash

### DIFF
--- a/ssh-key/src/mpint.rs
+++ b/ssh-key/src/mpint.rs
@@ -3,6 +3,7 @@
 use crate::{Error, Result};
 use alloc::vec::Vec;
 use core::fmt;
+use core::hash::{Hash, Hasher};
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
@@ -111,6 +112,12 @@ impl Eq for Mpint {}
 impl PartialEq for Mpint {
     fn eq(&self, other: &Self) -> bool {
         self.ct_eq(other).into()
+    }
+}
+
+impl Hash for Mpint {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash(state)
     }
 }
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -78,7 +78,7 @@ use std::{fs, path::Path};
 /// The serialization uses a binary encoding with binary formats like bincode
 /// and CBOR, and the OpenSSH string serialization when used with
 /// human-readable formats like JSON and TOML.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PublicKey {
     /// Key data.
     pub(crate) key_data: KeyData,

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -6,7 +6,7 @@ use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 /// Digital Signature Algorithm (DSA) public key.
 ///
 /// Described in [FIPS 186-4 § 4.1](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DsaPublicKey {
     /// Prime modulus.
     pub p: Mpint,

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -20,7 +20,7 @@ pub type EcdsaNistP521PublicKey = sec1::EncodedPoint<U66>;
 /// `sec1` feature of this crate is enabled (which it is by default).
 ///
 /// Described in [FIPS 186-4](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum EcdsaPublicKey {
     /// NIST P-256 ECDSA public key.
     NistP256(EcdsaNistP256PublicKey),

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -11,7 +11,7 @@ use super::{DsaPublicKey, OpaquePublicKey, RsaPublicKey};
 use super::{EcdsaPublicKey, SkEcdsaSha2NistP256};
 
 /// Public key data.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, Ord, Eq, PartialEq, PartialOrd)]
 #[non_exhaustive]
 pub enum KeyData {
     /// Digital Signature Algorithm (DSA) public key data.

--- a/ssh-key/src/public/opaque.rs
+++ b/ssh-key/src/public/opaque.rs
@@ -16,7 +16,7 @@ use encoding::{Decode, Encode, Reader, Writer};
 ///
 /// The encoded representation of an `OpaquePublicKey` is the encoded representation of its
 /// [`OpaquePublicKeyBytes`].
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct OpaquePublicKey {
     /// The [`Algorithm`] of this public key.
     pub algorithm: Algorithm,
@@ -28,7 +28,7 @@ pub struct OpaquePublicKey {
 ///
 /// The encoded representation of an `OpaquePublicKeyBytes` consists of a 4-byte length prefix,
 /// followed by its byte representation.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct OpaquePublicKeyBytes(Vec<u8>);
 
 impl OpaquePublicKey {

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -13,7 +13,7 @@ use {
 /// RSA public key.
 ///
 /// Described in [RFC4253 § 6.6](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6).
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RsaPublicKey {
     /// RSA public exponent.
     pub e: Mpint,

--- a/ssh-key/src/public/sk.rs
+++ b/ssh-key/src/public/sk.rs
@@ -18,7 +18,7 @@ const DEFAULT_APPLICATION_STRING: &str = "ssh:";
 /// Security Key (FIDO/U2F) ECDSA/NIST P-256 public key as specified in
 /// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
 #[cfg(feature = "ecdsa")]
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
 pub struct SkEcdsaSha2NistP256 {
     /// Elliptic curve point representing a public key.
     ec_point: EcdsaNistP256PublicKey,
@@ -112,7 +112,7 @@ impl From<SkEcdsaSha2NistP256> for EcdsaNistP256PublicKey {
 
 /// Security Key (FIDO/U2F) Ed25519 public key as specified in
 /// [PROTOCOL.u2f](https://cvsweb.openbsd.org/src/usr.bin/ssh/PROTOCOL.u2f?annotate=HEAD).
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct SkEd25519 {
     /// Ed25519 public key.
     public_key: Ed25519PublicKey,

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -2,6 +2,7 @@
 
 use hex_literal::hex;
 use ssh_key::{Algorithm, PublicKey};
+use std::collections::HashSet;
 
 #[cfg(feature = "ecdsa")]
 use ssh_key::EcdsaCurve;
@@ -377,4 +378,11 @@ fn encode_rsa_3072_openssh() {
 fn encode_rsa_4096_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_RSA_4096_EXAMPLE).unwrap();
     assert_eq!(OPENSSH_RSA_4096_EXAMPLE.trim_end(), &key.to_string());
+}
+
+#[test]
+fn public_keys_are_hashable() {
+    let key = PublicKey::from_openssh(OPENSSH_ED25519_EXAMPLE).unwrap();
+    let set = HashSet::from([&key]);
+    assert_eq!(true, set.contains(&key));
 }


### PR DESCRIPTION
Implementing the Hash trait enables using PublicKeys and relatives as HashMap keys and in HashSets.