### PR TITLE
ssh-encoding v0.2.0

### DIFF
--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.60"
 
 [dependencies]
 cipher = "0.4"
-encoding = { package = "ssh-encoding", version = "=0.2.0-pre.0", path = "../ssh-encoding" }
+encoding = { package = "ssh-encoding", version = "0.2", path = "../ssh-encoding" }
 
 # optional dependencies
 aes = { version = "0.8", optional = true, default-features = false }

--- a/ssh-encoding/CHANGELOG.md
+++ b/ssh-encoding/CHANGELOG.md
@@ -4,5 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2023-08-11)
+### Added
+- `LabelError` ([#124])
+- `bytes` feature ([#138])
+
+### Changed
+- Bump `pem-rfc7468` to v0.7 ([#84])
+
+### Removed
+- `Encoding::Error` ([#124])
+
+[#84]: https://github.com/RustCrypto/SSH/pull/84
+[#124]: https://github.com/RustCrypto/SSH/pull/124
+[#138]: https://github.com/RustCrypto/SSH/pull/138
+
 ## 0.1.0 (2022-10-23)
 - Initial release

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-encoding"
-version = "0.2.0-pre.0"
+version = "0.2.0"
 description = """
 Pure Rust implementation of SSH data type decoders/encoders as described
 in RFC4251

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 
 [dependencies]
 cipher = { package = "ssh-cipher", version = "=0.1.0-pre.0", path = "../ssh-cipher" }
-encoding = { package = "ssh-encoding", version = "=0.2.0-pre.0", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
+encoding = { package = "ssh-encoding", version = "0.2", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
 sha2 = { version = "0.10.7", default-features = false }
 signature = { version = "2", default-features = false }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
### Added
- `LabelError` ([#124])
- `bytes` feature ([#138])

### Changed
- Bump `pem-rfc7468` to v0.7 ([#84])

### Removed
- `Encoding::Error` ([#124])

[#84]: https://github.com/RustCrypto/SSH/pull/84
[#124]: https://github.com/RustCrypto/SSH/pull/124
[#138]: https://github.com/RustCrypto/SSH/pull/138