### PR TITLE
ssh-key: `Hash` impl cleanups

### DIFF
--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -1,12 +1,13 @@
 //! Digital Signature Algorithm (DSA) public keys.
 
 use crate::{Error, Mpint, Result};
+use core::hash::{Hash, Hasher};
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 
 /// Digital Signature Algorithm (DSA) public key.
 ///
 /// Described in [FIPS 186-4 § 4.1](https://csrc.nist.gov/publications/detail/fips/186/4/final).
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct DsaPublicKey {
     /// Prime modulus.
     pub p: Mpint,
@@ -50,6 +51,16 @@ impl Encode for DsaPublicKey {
         self.q.encode(writer)?;
         self.g.encode(writer)?;
         self.y.encode(writer)
+    }
+}
+
+impl Hash for DsaPublicKey {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.p.as_bytes().hash(state);
+        self.q.as_bytes().hash(state);
+        self.g.as_bytes().hash(state);
+        self.y.as_bytes().hash(state);
     }
 }
 

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -11,7 +11,7 @@ use super::{DsaPublicKey, OpaquePublicKey, RsaPublicKey};
 use super::{EcdsaPublicKey, SkEcdsaSha2NistP256};
 
 /// Public key data.
-#[derive(Clone, Debug, Hash, Ord, Eq, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum KeyData {
     /// Digital Signature Algorithm (DSA) public key data.

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -1,6 +1,7 @@
 //! Rivest–Shamir–Adleman (RSA) public keys.
 
 use crate::{Error, Mpint, Result};
+use core::hash::{Hash, Hasher};
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 
 #[cfg(feature = "rsa")]
@@ -13,7 +14,7 @@ use {
 /// RSA public key.
 ///
 /// Described in [RFC4253 § 6.6](https://datatracker.ietf.org/doc/html/rfc4253#section-6.6).
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RsaPublicKey {
     /// RSA public exponent.
     pub e: Mpint,
@@ -46,6 +47,14 @@ impl Encode for RsaPublicKey {
     fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
         self.e.encode(writer)?;
         self.n.encode(writer)
+    }
+}
+
+impl Hash for RsaPublicKey {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.e.as_bytes().hash(state);
+        self.n.as_bytes().hash(state);
     }
 }
 


### PR DESCRIPTION
Don't impl `Hash` on `Mpint` which contains potentially secret data. Instead, have the caller determine if a particular `Mpint` is safe to `Hash` and then explicitly pass its data to the relevant `Hasher`.