### PR TITLE
ssh-key v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 (2023-08-15)
+### Fixed
+- `minimal-versions` correctness for `sec1` dependency ([#154])
+
+[#154]: https://github.com/RustCrypto/SSH/pull/154
+
 ## 0.6.0 (2023-08-13)
 ### Added
 - Partial support for U2F signature verification ([#44])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.0"
+version = "0.6.1"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and


### PR DESCRIPTION
### Fixed
- `minimal-versions` correctness for `sec1` dependency ([#154])

[#154]: https://github.com/RustCrypto/SSH/pull/154