### PR TITLE
ssh-key v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 (2023-10-15)
+### Added
+- `SshSig` usage examples ([#166], [#167])
+
+[#166]: https://github.com/RustCrypto/SSH/pull/166
+[#167]: https://github.com/RustCrypto/SSH/pull/167
+
 ## 0.6.1 (2023-08-15)
 ### Fixed
 - `minimal-versions` correctness for `sec1` dependency ([#154])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.1"
+version = "0.6.2"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -26,6 +26,7 @@
 //! - [`Fingerprint`]: public key fingerprints (i.e. hashes)
 //! - [`PrivateKey`]: SSH private keys (i.e. digital signature keys)
 //! - [`PublicKey`]: SSH public keys (i.e. signature verification keys)
+//! - [`SshSig`]: signatures with SSH keys ala `ssh-keygen -Y sign`/`ssh-keygen -Y verify`
 //!
 //! ### Parsing OpenSSH Public Keys
 //!


### PR DESCRIPTION
### Added
- `SshSig` usage examples ([#166], [#167])

[#166]: https://github.com/RustCrypto/SSH/pull/166
[#167]: https://github.com/RustCrypto/SSH/pull/167