### PR TITLE
ssh-key: Implement SkEcdsaSha2NistP256 signature validation

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -154,7 +154,7 @@ fn ecdsa_sig_size(data: &Vec<u8>, curve: EcdsaCurve, sk_trailer: bool) -> Result
         }
     }
     if sk_trailer {
-        reader.drain(5)?;
+        reader.drain(SK_SIGNATURE_TRAILER_SIZE)?;
     }
     reader
         .finish(())

--- a/ssh-key/tests/examples/id_sk_ecdsa_p256_2.pub
+++ b/ssh-key/tests/examples/id_sk_ecdsa_p256_2.pub
@@ -1,0 +1,1 @@
+sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBNdo6XfhTK080uz5UbGyOcNMo+R3nPXMBxurwH2M1bDtQYbDT6qBE7EdQGkcy/EJDXbzT0KlU9rROjcX+JsgtGAAAAAEc3NoOg== user@example.com


### PR DESCRIPTION
I recently obtained a Yubikey Series 5 hardware token with the ability to generate and use sk-ecdsa type keys with openssh. It seemed like a good addition to the ssh-key crate to implement validation of signatures generated using such keys, as this is not yet supported and depending on firmware version of the hardware token, this is sometimes the only key type it can handle.

The signature is generated with OpenSSH_9.5p1 tools and the resulting signature is captured using my https://github.com/nresare/ssh-agent-client-rs library

I have made some slightly more opinionated changes compared to last time around, breaking out shared functionality into private helper functions in signature.rs. Just let me know what you think, and I'm happy to restructure to match your preferences.