### PR TITLE
ssh-key: set maximum `UnixTime` to `i64::MAX`

### DIFF
--- a/ssh-key/src/certificate/unix_time.rs
+++ b/ssh-key/src/certificate/unix_time.rs
@@ -8,13 +8,8 @@ use encoding::{Decode, Encode, Reader, Writer};
 #[cfg(feature = "std")]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-/// Maximum allowed value for a Unix timestamp:
-///
-/// 9999-12-31 23:59:59 UTC
-///
-/// This is a sanity limit intended to catch nonsense values which are
-/// excessively far in the future. Otherwise the limit is `i64::MAX`.
-pub const MAX_SECS: u64 = 253402300799;
+/// Maximum allowed value for a Unix timestamp.
+pub const MAX_SECS: u64 = i64::MAX as u64;
 
 /// Unix timestamps as used in OpenSSH certificates.
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]


### PR DESCRIPTION
`ssh-keygen` uses `i64::MAX` as its placeholder value for certificates which last "forever".

This allows such certificates to parse, albeit at the cost of allowing all sorts of bogus timestamps.

Closes #174