### PR TITLE
ssh-key: `p521` feature

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -49,14 +49,10 @@ jobs:
       - run: cargo build --target ${{ matrix.target }} --release --all-features
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo +nightly update -Z minimal-versions
-      - uses: dtolnay/rust-toolchain@1.65.0
-      - run: rm ../Cargo.toml
-      - run: cargo test --all-features --release
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      stable-cmd: cargo test --all-features --release
+      working-directory: ${{ github.workflow }}
 
   no_std:
     runs-on: ubuntu-latest
@@ -75,7 +71,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features crypto,default,getrandom,std --release
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features crypto,default,getrandom,p521,std --release
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +815,7 @@ dependencies = [
  "num-bigint-dig",
  "p256",
  "p384",
+ "p521",
  "rand_chacha",
  "rand_core",
  "rsa",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -31,6 +31,7 @@ dsa = { version = "0.6", optional = true, default-features = false }
 ed25519-dalek = { version = "2", optional = true, default-features = false }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.13.3", optional = true, default-features = false, features = ["ecdsa", "getrandom"] } # TODO(tarcieri): RFC6979
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 rsa = { version = "0.9", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.7.3", optional = true, default-features = false, features = ["point"] }
@@ -53,12 +54,13 @@ std = [
     "encoding/std",
     "p256?/std",
     "p384?/std",
+    "p521?/std",
     "rsa?/std",
     "sec1?/std",
     "signature/std"
 ]
 
-crypto = ["ed25519", "p256", "p384", "rsa"] # NOTE: `dsa` is obsolete/weak
+crypto = ["ed25519", "p256", "p384", "p521", "rsa"] # NOTE: `dsa` is obsolete/weak
 dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand_core"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
@@ -74,6 +76,7 @@ encryption = [
 getrandom = ["rand_core/getrandom"]
 p256 = ["dep:p256", "ecdsa"]
 p384 = ["dep:p384", "ecdsa"]
+p521 = ["dep:p521", "ecdsa"]
 rsa = ["dep:bigint", "dep:rsa", "alloc", "rand_core"]
 tdes = ["cipher/tdes", "encryption"]
 

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -490,7 +490,7 @@ impl PrivateKey {
         let key_data = match algorithm {
             #[cfg(feature = "dsa")]
             Algorithm::Dsa => KeypairData::from(DsaKeypair::random(rng)?),
-            #[cfg(any(feature = "p256", feature = "p384"))]
+            #[cfg(any(feature = "p256", feature = "p384", feature = "p521"))]
             Algorithm::Ecdsa { curve } => KeypairData::from(EcdsaKeypair::random(rng, curve)?),
             #[cfg(feature = "ed25519")]
             Algorithm::Ed25519 => KeypairData::from(Ed25519Keypair::random(rng)),

--- a/ssh-key/src/public/ecdsa.rs
+++ b/ssh-key/src/public/ecdsa.rs
@@ -173,6 +173,15 @@ impl TryFrom<EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
     }
 }
 
+#[cfg(feature = "p521")]
+impl TryFrom<EcdsaPublicKey> for p521::ecdsa::VerifyingKey {
+    type Error = Error;
+
+    fn try_from(key: EcdsaPublicKey) -> Result<p521::ecdsa::VerifyingKey> {
+        p521::ecdsa::VerifyingKey::try_from(&key)
+    }
+}
+
 #[cfg(feature = "p256")]
 impl TryFrom<&EcdsaPublicKey> for p256::ecdsa::VerifyingKey {
     type Error = Error;
@@ -195,6 +204,20 @@ impl TryFrom<&EcdsaPublicKey> for p384::ecdsa::VerifyingKey {
         match public_key {
             EcdsaPublicKey::NistP384(key) => {
                 p384::ecdsa::VerifyingKey::from_encoded_point(key).map_err(|_| Error::Crypto)
+            }
+            _ => Err(Error::AlgorithmUnknown),
+        }
+    }
+}
+
+#[cfg(feature = "p521")]
+impl TryFrom<&EcdsaPublicKey> for p521::ecdsa::VerifyingKey {
+    type Error = Error;
+
+    fn try_from(public_key: &EcdsaPublicKey) -> Result<p521::ecdsa::VerifyingKey> {
+        match public_key {
+            EcdsaPublicKey::NistP521(key) => {
+                p521::ecdsa::VerifyingKey::from_encoded_point(key).map_err(|_| Error::Crypto)
             }
             _ => Err(Error::AlgorithmUnknown),
         }
@@ -226,5 +249,19 @@ impl From<p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
 impl From<&p384::ecdsa::VerifyingKey> for EcdsaPublicKey {
     fn from(key: &p384::ecdsa::VerifyingKey) -> EcdsaPublicKey {
         EcdsaPublicKey::NistP384(key.to_encoded_point(false))
+    }
+}
+
+#[cfg(feature = "p521")]
+impl From<p521::ecdsa::VerifyingKey> for EcdsaPublicKey {
+    fn from(key: p521::ecdsa::VerifyingKey) -> EcdsaPublicKey {
+        EcdsaPublicKey::from(&key)
+    }
+}
+
+#[cfg(feature = "p521")]
+impl From<&p521::ecdsa::VerifyingKey> for EcdsaPublicKey {
+    fn from(key: &p521::ecdsa::VerifyingKey) -> EcdsaPublicKey {
+        EcdsaPublicKey::NistP521(key.to_encoded_point(false))
     }
 }


### PR DESCRIPTION
Adds initial integration with the `p521` crate, including support for converting public and private keys to `p521` keys, as well as signing and verifying NIST P-521 signatures.

Note that there's a lot of redundancy/boilerplate repeated for `p256`, `p384`, and `p521` it would be nice to eventually DRY out, possibly using macros to write the impls.