### PR TITLE
ssh-key v0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.3 (2023-11-20)
+### Added
+- `SkEcdsaSha2NistP256` signature validation ([#169])
+- `p521` feature ([#180])
+
+### Changed
+- Maximum certificate timestamp time is now `i64::MAX` ([#175])
+
+### Fixed
+- Handle leading zeroes in `Mpint::from_positive_bytes` ([#171])
+
+[#169]: https://github.com/RustCrypto/SSH/pull/169
+[#171]: https://github.com/RustCrypto/SSH/pull/171
+[#175]: https://github.com/RustCrypto/SSH/pull/175
+[#180]: https://github.com/RustCrypto/SSH/pull/180
+
 ## 0.6.2 (2023-10-15)
 ### Added
 - `SshSig` usage examples ([#166], [#167])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.2"
+version = "0.6.3"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -71,7 +71,7 @@ respective SSH key algorithm.
 | `ssh‑dsa`                            | ✅     | ✅     | ✅   | ✅     | ✅️   | ✅️     | `dsa`     | `alloc` ️ |
 | `ssh‑ed25519`                        | ✅     | ✅     | ✅   | ✅️     | ✅️   | ✅     | `ed25519` | heapless |
 | `ssh‑rsa`                            | ✅     | ✅     | ✅   | ✅️     | ✅️   | ✅     | `rsa`     | `alloc`  |
-| `sk‑ecdsa‑sha2‑nistp256@openssh.com` | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ⛔️     | ⛔        | `alloc`  |
+| `sk‑ecdsa‑sha2‑nistp256@openssh.com` | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ✅️     | ⛔        | `alloc`  |
 | `sk‑ssh‑ed25519@openssh.com`         | ✅     | ✅     | ✅   | ⛔     | ⛔️   | ⛔️     | ⛔        | `alloc`  |
 
 By default *no algorithms are enabled* and you will get an


### PR DESCRIPTION
### Added
- `SkEcdsaSha2NistP256` signature validation ([#169])
- `p521` feature ([#180])

### Changed
- Maximum certificate timestamp time is now `i64::MAX` ([#175])

### Fixed
- Handle leading zeroes in `Mpint::from_positive_bytes` ([#171])

[#169]: https://github.com/RustCrypto/SSH/pull/169
[#171]: https://github.com/RustCrypto/SSH/pull/171
[#175]: https://github.com/RustCrypto/SSH/pull/175
[#180]: https://github.com/RustCrypto/SSH/pull/180