### PR TITLE
Add newline to `PublicKey::write_openssh_file` output

### DIFF
--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -232,7 +232,9 @@ impl PublicKey {
     /// Write public key as an OpenSSH-formatted file.
     #[cfg(feature = "std")]
     pub fn write_openssh_file(&self, path: &Path) -> Result<()> {
-        let encoded = self.to_openssh()?;
+        let mut encoded = self.to_openssh()?;
+        encoded.push('\n'); // TODO(tarcieri): OS-specific line endings?
+
         fs::write(path, encoded.as_bytes())?;
         Ok(())
     }

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -12,7 +12,7 @@ use ssh_key::LineEnding;
 #[cfg(all(feature = "std"))]
 use {
     ssh_key::PublicKey,
-    std::{io, process},
+    std::{io, path::PathBuf, process},
 };
 
 /// DSA OpenSSH-formatted public key
@@ -45,6 +45,12 @@ const OPENSSH_RSA_4096_EXAMPLE: &str = include_str!("examples/id_rsa_4096");
 /// OpenSSH-formatted private key with a custom algorithm name
 #[cfg(feature = "alloc")]
 const OPENSSH_OPAQUE_EXAMPLE: &str = include_str!("examples/id_opaque");
+
+/// Get a path into the `tests/scratch` directory.
+#[cfg(feature = "std")]
+pub fn scratch_path(filename: &str) -> PathBuf {
+    PathBuf::from(&format!("tests/scratch/{}", filename))
+}
 
 #[cfg(feature = "alloc")]
 #[test]
@@ -468,7 +474,7 @@ fn encoding_integration_test(private_key: PrivateKey) {
         .replace(':', "-")
         .replace('/', "_");
 
-    let path = std::path::PathBuf::from(&format!("tests/scratch/{}", fingerprint));
+    let path = scratch_path(&fingerprint);
 
     private_key
         .write_openssh_file(&path, LineEnding::LF)


### PR DESCRIPTION
Also adds an integration test to ensure that the file output matches what `ssh-keygen` generates byte-for-byte.

The `ToString` impl still omits the newline.

To avoid making breaking changes, it always uses `\n` as the newline, however perhaps in a future breaking release it could be changed to accept `LineEnding` so as to match `PrivateKey::write_openssh_file`.

Fixes #187.