### PR TITLE
ssh-key: add Algorithm::Other Signature support

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -109,6 +109,7 @@ impl Signature {
             Algorithm::SkEd25519 if data.len() == SK_ED25519_SIGNATURE_SIZE => (),
             Algorithm::SkEcdsaSha2NistP256 => ecdsa_sig_size(&data, EcdsaCurve::NistP256, true)?,
             Algorithm::Rsa { hash: Some(_) } => (),
+            Algorithm::Other(_) if data.len() > 0 => (),
             _ => return Err(encoding::Error::Length.into()),
         }
 

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -109,7 +109,7 @@ impl Signature {
             Algorithm::SkEd25519 if data.len() == SK_ED25519_SIGNATURE_SIZE => (),
             Algorithm::SkEcdsaSha2NistP256 => ecdsa_sig_size(&data, EcdsaCurve::NistP256, true)?,
             Algorithm::Rsa { hash: Some(_) } => (),
-            Algorithm::Other(_) if data.len() > 0 => (),
+            Algorithm::Other(_) if !data.is_empty() => (),
             _ => return Err(encoding::Error::Length.into()),
         }
 


### PR DESCRIPTION
This allows Signatures with `Algorithm::Other`. The only restriction is that the passed-in data must not be empty. The AlgorithmLabel already requires that the name follows [RFC 4251](https://www.rfc-editor.org/rfc/rfc4251.html#page-10) for "additional algorithms" meaning they have a algorithm name and an '@' followed by a domain.