### PR TITLE
ssh-key v0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.4 (2024-01-11)
+### Added
+- `Algorithm::Other` signature support ([#189])
+
+### Fixed
+- Add newline to `PublicKey::write_openssh_file` output ([#188])
+- `DsaKeypair::try_sign` format error ([#191])
+
+[#188]: https://github.com/RustCrypto/SSH/pull/188
+[#189]: https://github.com/RustCrypto/SSH/pull/189
+[#191]: https://github.com/RustCrypto/SSH/pull/191
+
 ## 0.6.3 (2023-11-20)
 ### Added
 - `SkEcdsaSha2NistP256` signature validation ([#169])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.3"
+version = "0.6.4"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and

--- a/ssh-key/LICENSE-MIT
+++ b/ssh-key/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2023 The RustCrypto Project Developers
+Copyright (c) 2021-2024 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
### Added
- `Algorithm::Other` signature support ([#189])

### Fixed
- Add newline to `PublicKey::write_openssh_file` output ([#188])
- `DsaKeypair::try_sign` format error ([#191])

[#188]: https://github.com/RustCrypto/SSH/pull/188
[#189]: https://github.com/RustCrypto/SSH/pull/189
[#191]: https://github.com/RustCrypto/SSH/pull/191