### PR TITLE
ssh-key: correct erroneous signature constants

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -560,7 +560,7 @@ impl TryFrom<&Signature> for p384::ecdsa::Signature {
 
         match signature.algorithm {
             Algorithm::Ecdsa {
-                curve: EcdsaCurve::NistP256,
+                curve: EcdsaCurve::NistP384,
             } => {
                 let reader = &mut signature.as_bytes();
                 let r = Mpint::decode(reader)?;
@@ -586,11 +586,11 @@ impl TryFrom<&Signature> for p521::ecdsa::Signature {
     type Error = Error;
 
     fn try_from(signature: &Signature) -> Result<p521::ecdsa::Signature> {
-        const FIELD_SIZE: usize = 48;
+        const FIELD_SIZE: usize = 66;
 
         match signature.algorithm {
             Algorithm::Ecdsa {
-                curve: EcdsaCurve::NistP256,
+                curve: EcdsaCurve::NistP521,
             } => {
                 let reader = &mut signature.as_bytes();
                 let r = Mpint::decode(reader)?;


### PR DESCRIPTION
The elliptic curve was misspecified for `p384::ecdsa::Signature` and `p521::ecdsa::Signature`.

Additionally P-521 had an incorrect field size.

Closes #197