### PR TITLE
ssh-key: return `encoding::Error::Length` from `Sk*` constructors

### DIFF
--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -80,12 +80,6 @@ pub enum Error {
         /// Version number.
         number: u32,
     },
-
-    /// Byte array is longer than allowed.
-    TooLong {
-        /// Bad length that did not pass validation check.
-        bad_len: usize,
-    },
 }
 
 impl fmt::Display for Error {
@@ -117,7 +111,6 @@ impl fmt::Display for Error {
                 "unexpected trailing data at end of message ({remaining} bytes)",
             ),
             Error::Version { number: version } => write!(f, "version unsupported: {version}"),
-            Error::TooLong { bad_len } => write!(f, "too long byte array: {bad_len}"),
         }
     }
 }

--- a/ssh-key/src/private/sk.rs
+++ b/ssh-key/src/private/sk.rs
@@ -43,9 +43,7 @@ impl SkEcdsaSha2NistP256 {
                 reserved: Vec::<u8>::new(),
             })
         } else {
-            Err(Error::TooLong {
-                bad_len: key_handle.len(),
-            })
+            Err(encoding::Error::Length.into())
         }
     }
 
@@ -136,9 +134,7 @@ impl SkEd25519 {
                 reserved: Vec::<u8>::new(),
             })
         } else {
-            Err(Error::TooLong {
-                bad_len: key_handle.len(),
-            })
+            Err(encoding::Error::Length.into())
         }
     }
 


### PR DESCRIPTION
Uses an existing error type for these constructors, rather than adding a new one.