### PR TITLE
ssh-key v0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.5 (2024-03-12)
+### Added
+- `Sk*` constructors ([#201], [#204])
+
+### Changed
+- Simplify DSA signature encoding ([#193])
+
+### Fixed
+- Correct erroneous signature constants ([#202])
+
+[#193]: https://github.com/RustCrypto/SSH/pull/193
+[#201]: https://github.com/RustCrypto/SSH/pull/201
+[#202]: https://github.com/RustCrypto/SSH/pull/202
+[#204]: https://github.com/RustCrypto/SSH/pull/204
+
 ## 0.6.4 (2024-01-11)
 ### Added
 - `Algorithm::Other` signature support ([#189])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.4"
+version = "0.6.5"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and


### PR DESCRIPTION
### Added
- `Sk*` constructors ([#201], [#204])

### Changed
- Simplify DSA signature encoding ([#193])

### Fixed
- Correct erroneous signature constants ([#202])

[#193]: https://github.com/RustCrypto/SSH/pull/193
[#201]: https://github.com/RustCrypto/SSH/pull/201
[#202]: https://github.com/RustCrypto/SSH/pull/202
[#204]: https://github.com/RustCrypto/SSH/pull/204