### PR TITLE
Critical options String values double-length encoding

### DIFF
--- a/ssh-key/src/certificate/options_map.rs
+++ b/ssh-key/src/certificate/options_map.rs
@@ -42,7 +42,13 @@ impl Decode for OptionsMap {
 
             while !reader.is_finished() {
                 let name = String::decode(reader)?;
-                let data = String::decode(reader)?;
+                // strings are double-length encoded.
+                let data_vec = Vec::decode(reader)?;
+                let data = if data_vec.is_empty() {
+                    String::new()
+                } else {
+                    String::decode(&mut data_vec.as_ref())?
+                };
 
                 // Options must be lexically ordered by "name" if they appear in
                 // the sequence. Each named option may only appear once in a

--- a/ssh-key/src/certificate/options_map.rs
+++ b/ssh-key/src/certificate/options_map.rs
@@ -42,7 +42,13 @@ impl Decode for OptionsMap {
 
             while !reader.is_finished() {
                 let name = String::decode(reader)?;
-                let data = reader.read_prefixed(String::decode)?;
+                let data = reader.read_prefixed(|reader| {
+                    if reader.remaining_len() > 0 {
+                        String::decode(reader)
+                    } else {
+                        Ok(String::default())
+                    }
+                })?;
 
                 // Options must be lexically ordered by "name" if they appear in
                 // the sequence. Each named option may only appear once in a
@@ -65,7 +71,16 @@ impl Encode for OptionsMap {
     fn encoded_len(&self) -> encoding::Result<usize> {
         self.iter()
             .try_fold(4, |acc, (name, data)| {
-                [acc, name.encoded_len()?, data.encoded_len_prefixed()?].checked_sum()
+                [
+                    acc,
+                    name.encoded_len()?,
+                    if data.is_empty() {
+                        4
+                    } else {
+                        data.encoded_len_prefixed()?
+                    },
+                ]
+                .checked_sum()
             })
             .map_err(Into::into)
     }
@@ -78,7 +93,11 @@ impl Encode for OptionsMap {
 
         for (name, data) in self.iter() {
             name.encode(writer)?;
-            data.encode_prefixed(writer)?
+            if data.is_empty() {
+                0usize.encode(writer)?;
+            } else {
+                data.encode_prefixed(writer)?
+            }
         }
 
         Ok(())

--- a/ssh-key/src/certificate/options_map.rs
+++ b/ssh-key/src/certificate/options_map.rs
@@ -42,7 +42,6 @@ impl Decode for OptionsMap {
 
             while !reader.is_finished() {
                 let name = String::decode(reader)?;
-
                 let data = reader.read_prefixed(String::decode)?;
 
                 // Options must be lexically ordered by "name" if they appear in
@@ -79,7 +78,6 @@ impl Encode for OptionsMap {
 
         for (name, data) in self.iter() {
             name.encode(writer)?;
-
             data.encode_prefixed(writer)?
         }
 

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -140,6 +140,19 @@ fn decode_ed25519_openssh() {
 }
 
 #[test]
+fn decode_ed25519_openssh_with_crit_options() {
+    let cert = Certificate::from_str("ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIBW/4zLqXWROWmN1sPgdySnH1GUsEFBjFrRwKKw71BoBAAAAIH1MFwI1oRdEifXgBQvWQfCBBtA/Pi8YCUE/I3wXFJo2AAAAAAAAAAAAAAABAAAAA2ZvbwAAAAAAAAAAAAAAAH//////////AAAAIwAAABFoZWxsb0BleGFtcGxlLmNvbQAAAAoAAAAGZm9vYmFyAAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIH1MFwI1oRdEifXgBQvWQfCBBtA/Pi8YCUE/I3wXFJo2AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEDRoPdI48KyoaLgaDZsSGs80qBeYQOXBd84CX8GYzFt/L21rxF1EeuPOkgsx7Q39WllXp+FgMMojsHftK/DJHEN").unwrap();
+
+    assert_eq!(Algorithm::Ed25519, cert.public_key().algorithm());
+
+    assert_eq!(cert.critical_options().len(), 1);
+    assert_eq!(
+        cert.critical_options().get("hello@example.com").unwrap(),
+        "foobar"
+    );
+}
+
+#[test]
 fn decode_rsa_4096_openssh() {
     let cert = Certificate::from_str(RSA_4096_CERT_EXAMPLE).unwrap();
     assert_eq!(Algorithm::Rsa { hash: None }, cert.public_key().algorithm());

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -141,7 +141,8 @@ fn decode_ed25519_openssh() {
 
 #[test]
 fn decode_ed25519_openssh_with_crit_options() {
-    let cert = Certificate::from_str("ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIBW/4zLqXWROWmN1sPgdySnH1GUsEFBjFrRwKKw71BoBAAAAIH1MFwI1oRdEifXgBQvWQfCBBtA/Pi8YCUE/I3wXFJo2AAAAAAAAAAAAAAABAAAAA2ZvbwAAAAAAAAAAAAAAAH//////////AAAAIwAAABFoZWxsb0BleGFtcGxlLmNvbQAAAAoAAAAGZm9vYmFyAAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIH1MFwI1oRdEifXgBQvWQfCBBtA/Pi8YCUE/I3wXFJo2AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEDRoPdI48KyoaLgaDZsSGs80qBeYQOXBd84CX8GYzFt/L21rxF1EeuPOkgsx7Q39WllXp+FgMMojsHftK/DJHEN").unwrap();
+    let src = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIBW/4zLqXWROWmN1sPgdySnH1GUsEFBjFrRwKKw71BoBAAAAIH1MFwI1oRdEifXgBQvWQfCBBtA/Pi8YCUE/I3wXFJo2AAAAAAAAAAAAAAABAAAAA2ZvbwAAAAAAAAAAAAAAAH//////////AAAAIwAAABFoZWxsb0BleGFtcGxlLmNvbQAAAAoAAAAGZm9vYmFyAAAAAAAAAAAAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIH1MFwI1oRdEifXgBQvWQfCBBtA/Pi8YCUE/I3wXFJo2AAAAUwAAAAtzc2gtZWQyNTUxOQAAAEDRoPdI48KyoaLgaDZsSGs80qBeYQOXBd84CX8GYzFt/L21rxF1EeuPOkgsx7Q39WllXp+FgMMojsHftK/DJHEN";
+    let cert = Certificate::from_str(src).unwrap();
 
     assert_eq!(Algorithm::Ed25519, cert.public_key().algorithm());
 
@@ -150,6 +151,12 @@ fn decode_ed25519_openssh_with_crit_options() {
         cert.critical_options().get("hello@example.com").unwrap(),
         "foobar"
     );
+
+    let openssh = cert.to_openssh().unwrap();
+
+    assert_eq!(openssh, src);
+
+    assert_eq!(cert, Certificate::from_str(&openssh).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
There was recent clarification on how critical options values should be read: https://bugzilla.mindrot.org/show_bug.cgi?id=2389

The gist of it is that values can be of any kind, but they generally are strings. To support more types, the value is encoded in a more generic way. For a string, this means there are 2 length prefixes (4 bytes for the total length of the value and then 4 bytes for the length of the string).

This PR aims at fixing this issue.