### PR TITLE
ssh-key: use `u64` type for certificate timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-cipher"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-encoding"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "base64ct",
  "bytes",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.5"
+version = "0.7.0-pre"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-cipher"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of SSH symmetric encryption including support for the
 modern aes128-gcm@openssh.com/aes256-gcm@openssh.com and
@@ -18,8 +18,8 @@ edition = "2021"
 rust-version = "1.72"
 
 [dependencies]
-cipher = "0.5.0-pre.4"
-encoding = { package = "ssh-encoding", version = "0.2", path = "../ssh-encoding" }
+cipher = "=0.5.0-pre.4"
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre", path = "../ssh-encoding" }
 
 # optional dependencies
 aes = { version = "=0.9.0-pre", optional = true, default-features = false }

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-encoding"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 Pure Rust implementation of SSH data type decoders/encoders as described
 in RFC4251

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.5"
+version = "0.7.0-pre"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and
@@ -17,8 +17,8 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-cipher = { package = "ssh-cipher", version = "0.2", path = "../ssh-cipher" }
-encoding = { package = "ssh-encoding", version = "0.2", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
+cipher = { package = "ssh-cipher", version = "=0.3.0-pre", path = "../ssh-cipher" }
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
 signature = { version = "=2.3.0-pre.3", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/ssh-key/src/authorized_keys.rs
+++ b/ssh-key/src/authorized_keys.rs
@@ -36,7 +36,7 @@ const COMMENT_DELIMITER: char = '#';
 ///   the key).
 pub struct AuthorizedKeys<'a> {
     /// Lines of the file being iterated over
-    lines: core::str::Lines<'a>,
+    lines: str::Lines<'a>,
 }
 
 impl<'a> AuthorizedKeys<'a> {

--- a/ssh-key/src/certificate/builder.rs
+++ b/ssh-key/src/certificate/builder.rs
@@ -1,6 +1,6 @@
 //! OpenSSH certificate builder.
 
-use super::{unix_time::UnixTime, CertType, Certificate, Field, OptionsMap};
+use super::{CertType, Certificate, Field, OptionsMap};
 use crate::{public, Result, Signature, SigningKey};
 use alloc::{string::String, vec::Vec};
 
@@ -8,7 +8,7 @@ use alloc::{string::String, vec::Vec};
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "std")]
-use std::time::SystemTime;
+use {super::UnixTime, std::time::SystemTime};
 
 #[cfg(doc)]
 use crate::PrivateKey;
@@ -84,8 +84,8 @@ pub struct Builder {
     cert_type: Option<CertType>,
     key_id: Option<String>,
     valid_principals: Option<Vec<String>>,
-    valid_after: UnixTime,
-    valid_before: UnixTime,
+    valid_after: u64,
+    valid_before: u64,
     critical_options: OptionsMap,
     extensions: OptionsMap,
     comment: Option<String>,
@@ -105,12 +105,6 @@ impl Builder {
         valid_after: u64,
         valid_before: u64,
     ) -> Result<Self> {
-        let valid_after =
-            UnixTime::new(valid_after).map_err(|_| Field::ValidAfter.invalid_error())?;
-
-        let valid_before =
-            UnixTime::new(valid_before).map_err(|_| Field::ValidBefore.invalid_error())?;
-
         if valid_before < valid_after {
             return Err(Field::ValidBefore.invalid_error());
         }
@@ -304,7 +298,7 @@ impl Builder {
 
         #[cfg(debug_assertions)]
         cert.validate_at(
-            cert.valid_after.into(),
+            cert.valid_after,
             &[cert.signature_key.fingerprint(Default::default())],
         )?;
 

--- a/ssh-key/src/known_hosts.rs
+++ b/ssh-key/src/known_hosts.rs
@@ -46,7 +46,7 @@ const MAGIC_HASH_PREFIX: &str = "|1|";
 ///   the key).
 pub struct KnownHosts<'a> {
     /// Lines of the file being iterated over
-    lines: core::str::Lines<'a>,
+    lines: str::Lines<'a>,
 }
 
 impl<'a> KnownHosts<'a> {


### PR DESCRIPTION
Closes #174

Previously certificates only supported the `i64` range to allow for infallible conversions to/from `SystemTime`.

Unfortunately OpenSSH defaults to using `u64::MAX` as the `valid_before` time in order to represent certificate that's valid "forever". The previous restriction meant that `ssh-key` was incapible of parsing such certificates.

This commit switches to using a raw `u64` everywhere, and changing conversions to `SystemTime` to return an `Option<SystemTime>` which is `None` if the `u64` value overflows an `i64`.