### PR TITLE
Add 'boolean' encode/decode support (ssh-encoding)

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -62,6 +62,26 @@ impl Decode for u8 {
     }
 }
 
+/// Decode a `boolean` as described in [RFC4251 § 5]:
+///
+/// > A boolean value is stored as a single byte.  The value 0
+/// > represents FALSE, and the value 1 represents TRUE.  All non-zero
+/// > values MUST be interpreted as TRUE; however, applications MUST NOT
+/// > store values other than 0 and 1.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Decode for bool {
+    type Error = Error;
+
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        let byte = u8::decode(reader)?;
+        match byte {
+            0 => Ok(false),
+            _ => Ok(true),
+        }
+    }
+}
+
 /// Decode a `uint32` as described in [RFC4251 § 5]:
 ///
 /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -98,6 +98,28 @@ impl Encode for u8 {
     }
 }
 
+/// Encode a `boolean` as described in [RFC4251 § 5]:
+///
+/// > A boolean value is stored as a single byte.  The value 0
+/// > represents FALSE, and the value 1 represents TRUE.  All non-zero
+/// > values MUST be interpreted as TRUE; however, applications MUST NOT
+/// > store values other than 0 and 1.
+///
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+impl Encode for bool {
+    fn encoded_len(&self) -> Result<usize, Error> {
+        Ok(1)
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        if *self {
+            1u8.encode(writer)
+        } else {
+            0u8.encode(writer)
+        }
+    }
+}
+
 /// Encode a `uint32` as described in [RFC4251 § 5]:
 ///
 /// > Represents a 32-bit unsigned integer.  Stored as four bytes in the

--- a/ssh-encoding/tests/decode.rs
+++ b/ssh-encoding/tests/decode.rs
@@ -11,6 +11,18 @@ fn decode_u8() {
 }
 
 #[test]
+fn decode_boolean() {
+    let mut bytes = hex!("01").as_slice();
+    let ret = bool::decode(&mut bytes).unwrap();
+    assert_eq!(ret, true);
+
+    // "All non-zero values MUST be interpreted as TRUE"
+    let mut bytes = hex!("FF").as_slice();
+    let ret = bool::decode(&mut bytes).unwrap();
+    assert_eq!(ret, true);
+}
+
+#[test]
 fn decode_u32() {
     let mut bytes = hex!("DEADBEEF").as_slice();
     let ret = u32::decode(&mut bytes).unwrap();

--- a/ssh-encoding/tests/encode.rs
+++ b/ssh-encoding/tests/encode.rs
@@ -13,6 +13,13 @@ fn encode_u8() {
 }
 
 #[test]
+fn encode_boolean() {
+    let mut out = Vec::new();
+    true.encode(&mut out).unwrap();
+    assert_eq!(out, hex!("01"));
+}
+
+#[test]
 fn encode_u32() {
     let mut out = Vec::new();
     0xDEADBEEFu32.encode(&mut out).unwrap();


### PR DESCRIPTION
This PR adds `Encode` and `Decode` traits for `boolean` types, as described in [RFC4251 § 5](https://datatracker.ietf.org/doc/html/rfc4251#section-5).

This is a pretty simple type (encodes as `0u8` or `1u8`) but adding for completeness.