### PR TITLE
Fix comment for Vec<u8> decoding

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -135,11 +135,14 @@ impl<const N: usize> Decode for [u8; N] {
     }
 }
 
-/// Decodes `Vec<u8>` from `byte[n]` as described in [RFC4251 § 5]:
+/// Decodes `Vec<u8>` from `string` as described in [RFC4251 § 5]:
 ///
-/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
-/// > data is sometimes represented as an array of bytes, written
-/// > `byte[n]`, where n is the number of bytes in the array.
+/// > Arbitrary length binary string.  Strings are allowed to contain
+/// > arbitrary binary data, including null characters and 8-bit
+/// > characters.  They are stored as a uint32 containing its length
+/// > (number of bytes that follow) and zero (= empty string) or more
+/// > bytes that are the value of the string.  Terminating null
+/// > characters are not used.
 ///
 /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
The previous comment seems to have been a copy-pasta from the previous method, because reading Vec<u8> follows the logic for string reading (LV) rather than pre-defined length, which is how byte[] works.