### PR TITLE
ssh-encoding: extract a `base64` module

### DIFF
--- a/ssh-encoding/src/base64.rs
+++ b/ssh-encoding/src/base64.rs
@@ -1,0 +1,7 @@
+//! Base64 support.
+
+mod reader;
+mod writer;
+
+pub use self::{reader::Base64Reader, writer::Base64Writer};
+pub use base64ct::{Base64, Base64Unpadded, Encoding, Error};

--- a/ssh-encoding/src/base64/reader.rs
+++ b/ssh-encoding/src/base64/reader.rs
@@ -1,7 +1,6 @@
 //! Base64 reader support (constant-time).
 
-use super::Reader;
-use crate::Result;
+use crate::{Reader, Result};
 
 /// Inner constant-time Base64 reader type from the `base64ct` crate.
 type Inner<'i> = base64ct::Decoder<'i, base64ct::Base64>;

--- a/ssh-encoding/src/base64/writer.rs
+++ b/ssh-encoding/src/base64/writer.rs
@@ -1,7 +1,6 @@
 //! Base64 writer support (constant-time).
 
-use super::Writer;
-use crate::Result;
+use crate::{Result, Writer};
 
 /// Inner constant-time Base64 reader type from the `base64ct` crate.
 type Inner<'o> = base64ct::Encoder<'o, base64ct::Base64>;

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -31,6 +31,9 @@ mod label;
 mod reader;
 mod writer;
 
+#[cfg(feature = "base64")]
+pub mod base64;
+
 pub use crate::{
     checked::CheckedSum,
     decode::Decode,
@@ -42,10 +45,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "base64")]
-pub use {
-    crate::{reader::base64::Base64Reader, writer::base64::Base64Writer},
-    base64ct as base64,
-};
+pub use crate::{base64::Base64Reader, base64::Base64Writer};
 
 #[cfg(feature = "pem")]
 pub use {

--- a/ssh-encoding/src/reader.rs
+++ b/ssh-encoding/src/reader.rs
@@ -1,8 +1,5 @@
 //! Reader trait and associated implementations.
 
-#[cfg(feature = "base64")]
-pub(crate) mod base64;
-
 use crate::{decode::Decode, Error, Result};
 use core::str;
 

--- a/ssh-encoding/src/writer.rs
+++ b/ssh-encoding/src/writer.rs
@@ -1,8 +1,5 @@
 //! Writer trait and associated implementations.
 
-#[cfg(feature = "base64")]
-pub(crate) mod base64;
-
 use crate::Result;
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Moves all Base64-related encoding support into a `base64` module