### PR TITLE
clippy: add import lints for `core`/`alloc`/`std`

### DIFF
--- a/ssh-cipher/src/lib.rs
+++ b/ssh-cipher/src/lib.rs
@@ -7,9 +7,13 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::arithmetic_side_effects,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -7,9 +7,13 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::arithmetic_side_effects,
+    clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,

--- a/ssh-key/src/authorized_keys.rs
+++ b/ssh-key/src/authorized_keys.rs
@@ -10,7 +10,10 @@ use {
 };
 
 #[cfg(feature = "std")]
-use std::{fs, path::Path, vec::Vec};
+use {
+    alloc::vec::Vec,
+    std::{fs, path::Path},
+};
 
 /// Character that begins a comment
 const COMMENT_DELIMITER: char = '#';

--- a/ssh-key/src/certificate/unix_time.rs
+++ b/ssh-key/src/certificate/unix_time.rs
@@ -6,7 +6,10 @@ use core::fmt::Formatter;
 use encoding::{Decode, Encode, Reader, Writer};
 
 #[cfg(feature = "std")]
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use {
+    core::time::Duration,
+    std::time::{SystemTime, UNIX_EPOCH},
+};
 
 /// Maximum allowed value for a Unix timestamp.
 pub const MAX_SECS: u64 = i64::MAX as u64;

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -7,10 +7,13 @@
 )]
 #![forbid(unsafe_code)]
 #![warn(
+    clippy::alloc_instead_of_core,
     clippy::arithmetic_side_effects,
     clippy::mod_module_files,
     clippy::panic,
     clippy::panic_in_result_fn,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     clippy::unwrap_used,
     missing_docs,
     rust_2018_idioms,


### PR DESCRIPTION
Helps ensure code remains friendly to heapless/alloc-only targets