### PR TITLE
ssh-key: disable `p521` getrandom feature

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -72,7 +72,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features crypto,default,getrandom,p521,std --release
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features crypto,default,getrandom,std --release
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,6 @@ dependencies = [
  "elliptic-curve",
  "primefield",
  "primeorder",
- "rand_core",
  "sha2",
 ]
 

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -31,7 +31,7 @@ dsa = { version = "=0.7.0-pre", optional = true, default-features = false }
 ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
 p256 = { version = "=0.14.0-pre.0", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "=0.14.0-pre", optional = true, default-features = false, features = ["ecdsa"] }
-p521 = { version = "=0.14.0-pre", optional = true, default-features = false, features = ["ecdsa", "getrandom"] } # TODO(tarcieri): RFC6979
+p521 = { version = "=0.14.0-pre", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 rsa = { version = "=0.10.0-pre.1", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "=0.8.0-pre.1", optional = true, default-features = false, features = ["point"] }


### PR DESCRIPTION
It was needed before `p521` had RFC6979 support, but is no longer necessary.