### PR TITLE
ssh-encoding: remove `NestedReader`

### DIFF
--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -32,6 +32,7 @@ mod decode;
 mod encode;
 mod error;
 mod label;
+#[macro_use]
 mod reader;
 mod writer;
 
@@ -46,7 +47,7 @@ pub use crate::{
     encode::Encode,
     error::{Error, Result},
     label::{Label, LabelError},
-    reader::{NestedReader, Reader},
+    reader::Reader,
     writer::Writer,
 };
 


### PR DESCRIPTION
Changes `Reader::read_prefixed` from a provided method to one which must be impl'd by all of the `Reader` types, of which there are currently three:

- `&[u8]`
- `Base64Reader`
- `PemReader`

This should reduce monomorphization bloat from `NestedReader` which encapsulates other reader types, including other `NestedReader`s, depending on the level of nesting, which is generally low, but good to eliminate entirely.

This does lead to a small amount of duplication between `Base64Reader` and `PemReader` which was previously encapsulated in `NestedReader`. It can possibly be eliminated in followup work.