### PR TITLE
ssh-key: reduce CI `no_std` build combos

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -72,7 +72,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features crypto,default,getrandom,std --release
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std --release
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features alloc,crypto,dsa,encryption,tdes --release
 
   test:
     runs-on: ubuntu-latest
@@ -87,10 +88,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --exclude-features crypto,default,dsa,getrandom,p256,p384,p521,rsa,tdes,std --release
+      - run: cargo hack test --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std --release
       - run: cargo test --release
-      - run: cargo test --release --features crypto
-      - run: cargo test --release --features encryption
       - run: cargo test --release --features getrandom
       - run: cargo test --release --features std
       - run: cargo test --all-features # debug build


### PR DESCRIPTION
The combinatorial explosion of features is leading to long CI times.

This reduces the number of combinations checked to something more manageable.