### PR TITLE
cargo: point `repository` metadata to clonable URLs

### DIFF
--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -10,7 +10,8 @@ RustCrypto organization.
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/RustCrypto/SSH/tree/master/ssh-cipher"
+homepage = "https://github.com/RustCrypto/SSH/tree/master/ssh-cipher"
+repository = "https://github.com/RustCrypto/SSH"
 categories = ["cryptography", "no-std"]
 keywords = ["crypto", "encryption", "openssh", "ssh"]
 readme = "README.md"

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -7,7 +7,8 @@ in RFC4251
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/RustCrypto/SSH/tree/master/ssh-encoding"
+homepage = "https://github.com/RustCrypto/SSH/tree/master/ssh-encoding"
+repository = "https://github.com/RustCrypto/SSH"
 categories = ["authentication", "cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "certificate", "key", "openssh", "ssh"]
 readme = "README.md"

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -9,7 +9,8 @@ with further support for the `authorized_keys` and `known_hosts` file formats.
 """
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/RustCrypto/SSH/tree/master/ssh-key"
+homepage = "https://github.com/RustCrypto/SSH/tree/master/ssh-key"
+repository = "https://github.com/RustCrypto/SSH"
 categories = ["authentication", "cryptography", "encoding", "no-std", "parser-implementations"]
 keywords = ["crypto", "certificate", "openssh", "ssh", "sshsig"]
 readme = "README.md"


### PR DESCRIPTION
This tweaks the `repository` fields in Cargo metadata in order to use the correct (i.e. git clonable) URL. The existing GitHub webUI URLs for each package have been retained and moved to `homepage` fields.