### PR TITLE
ssh-key: Add `Certificate::decode_as` and expose `KeyData::decode_as`

### DIFF
--- a/ssh-key/src/certificate.rs
+++ b/ssh-key/src/certificate.rs
@@ -455,14 +455,9 @@ impl Certificate {
         self.reserved.encode(writer)?;
         self.signature_key.encode_prefixed(writer)
     }
-}
 
-impl Decode for Certificate {
-    type Error = Error;
-
-    fn decode(reader: &mut impl Reader) -> Result<Self> {
-        let algorithm = Algorithm::new_certificate(&String::decode(reader)?)?;
-
+    /// Decode [`Certificate`] for the specified algorithm.
+    pub fn decode_as(reader: &mut impl Reader, algorithm: Algorithm) -> Result<Self> {
         Ok(Self {
             nonce: Vec::decode(reader)?,
             public_key: KeyData::decode_as(reader, algorithm)?,
@@ -479,6 +474,15 @@ impl Decode for Certificate {
             signature: reader.read_prefixed(Signature::decode)?,
             comment: String::new(),
         })
+    }
+}
+
+impl Decode for Certificate {
+    type Error = Error;
+
+    fn decode(reader: &mut impl Reader) -> Result<Self> {
+        let algorithm = Algorithm::new_certificate(&String::decode(reader)?)?;
+        Self::decode_as(reader, algorithm)
     }
 }
 

--- a/ssh-key/src/public/key_data.rs
+++ b/ssh-key/src/public/key_data.rs
@@ -174,7 +174,7 @@ impl KeyData {
     }
 
     /// Decode [`KeyData`] for the specified algorithm.
-    pub(crate) fn decode_as(reader: &mut impl Reader, algorithm: Algorithm) -> Result<Self> {
+    pub fn decode_as(reader: &mut impl Reader, algorithm: Algorithm) -> Result<Self> {
         match algorithm {
             #[cfg(feature = "alloc")]
             Algorithm::Dsa => DsaPublicKey::decode(reader).map(Self::Dsa),


### PR DESCRIPTION
This additional function is needed for SSH Agent Protocol where, based on
the algorithm, we need to parse the `Certificate` or the `KeyData`.

Without `decode_as` the `decode` function will greedily consume additional
string from the reader.

This is similar to https://github.com/RustCrypto/SSH/pull/211.

See: https://github.com/wiktor-k/ssh-agent-lib/issues/83