### PR TITLE
ssh-derive: initial implementation

### DIFF
--- a/.github/workflows/ssh-derive.yml
+++ b/.github/workflows/ssh-derive.yml
@@ -1,0 +1,38 @@
+name: ssh-derive
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ssh-derive.yml"
+      - "ssh-derive/**"
+      - "Cargo.*"
+  push:
+    branches: master
+
+defaults:
+  run:
+    working-directory: ssh-derive
+
+env:
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+      stable-cmd: cargo test --all-features --release
+      working-directory: ${{ github.workflow }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.60.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssh-derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ssh-encoding"
 version = "0.3.0-pre"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "ssh-cipher",
+    "ssh-derive",
     "ssh-encoding",
     "ssh-key"
 ]
@@ -12,40 +13,38 @@ opt-level = 2
 [patch.crates-io]
 # When you remove the last patch.crates-io entry, please re-enable `minimal-versions`
 # in `.github/workflows/ssh-key.yml` and `.github/workflows/ssh-cipher.yml`
-
-
-p256          = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p384          = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p521          = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
+p256 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
+p384 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
+p521 = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
 
 # https://github.com/RustCrypto/signatures/pull/807
-ed25519       = { git = "https://github.com/RustCrypto/signatures.git" }
+ed25519 = { git = "https://github.com/RustCrypto/signatures.git" }
 # https://github.com/dalek-cryptography/curve25519-dalek/pull/620
 ed25519-dalek = { git = "https://github.com/baloo/curve25519-dalek.git", branch = "baloo/rust-crypto/digest-sha2-bumps" }
 
-dsa           = { git = "https://github.com/RustCrypto/signatures.git" }
-ecdsa         = { git = "https://github.com/RustCrypto/signatures.git" }
+dsa = { git = "https://github.com/RustCrypto/signatures.git" }
+ecdsa = { git = "https://github.com/RustCrypto/signatures.git" }
 
 # https://github.com/RustCrypto/password-hashes/pull/489
-bcrypt-pbkdf  = { git = "https://github.com/RustCrypto/password-hashes.git" }
+bcrypt-pbkdf = { git = "https://github.com/RustCrypto/password-hashes.git" }
 
 # https://github.com/RustCrypto/stream-ciphers/pull/345
-chacha20      = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
+chacha20 = { git = "https://github.com/RustCrypto/stream-ciphers.git" }
 
 # https://github.com/RustCrypto/block-ciphers/pull/413
 # https://github.com/RustCrypto/block-ciphers/pull/419 - pending release
-blowfish      = { git = "https://github.com/RustCrypto/block-ciphers.git" }
+blowfish = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 
 # https://github.com/RustCrypto/block-modes/pull/56
-cbc           = { git = "https://github.com/RustCrypto/block-modes.git" }
-ctr           = { git = "https://github.com/RustCrypto/block-modes.git" }
+cbc = { git = "https://github.com/RustCrypto/block-modes.git" }
+ctr = { git = "https://github.com/RustCrypto/block-modes.git" }
 
 # https://github.com/RustCrypto/AEADs/pull/583
-aes-gcm       = { git = "https://github.com/RustCrypto/AEADs.git" }
+aes-gcm = { git = "https://github.com/RustCrypto/AEADs.git" }
 
-der            = { git = "https://github.com/RustCrypto/formats.git" }
-pkcs1          = { git = "https://github.com/RustCrypto/formats.git" }
-pkcs8          = { git = "https://github.com/RustCrypto/formats.git" }
-sec1           = { git = "https://github.com/RustCrypto/formats.git" }
-spki           = { git = "https://github.com/RustCrypto/formats.git" }
+der = { git = "https://github.com/RustCrypto/formats.git" }
+pkcs1 = { git = "https://github.com/RustCrypto/formats.git" }
+pkcs8 = { git = "https://github.com/RustCrypto/formats.git" }
+sec1 = { git = "https://github.com/RustCrypto/formats.git" }
+spki = { git = "https://github.com/RustCrypto/formats.git" }
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Pure Rust implementation of components of the Secure Shell ([SSH]) protocol.
 
 | Name           | crates.io                                                                                               | Docs                                                                                     | Description                                          |
 |----------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|------------------------------------------------------|
-| `ssh‑cipher`   | [![crates.io](https://img.shields.io/crates/v/ssh-cipher.svg)](https://crates.io/crates/ssh-cipher)     | [![Documentation](https://docs.rs/ssh-cipher/badge.svg)](https://docs.rs/ssh-cipher) | SSH symmetric encryption ciphers 
+| `ssh‑cipher`   | [![crates.io](https://img.shields.io/crates/v/ssh-cipher.svg)](https://crates.io/crates/ssh-cipher)     | [![Documentation](https://docs.rs/ssh-cipher/badge.svg)](https://docs.rs/ssh-cipher)     | SSH symmetric encryption ciphers                     |
+| `ssh‑derive`   | [![crates.io](https://img.shields.io/crates/v/ssh-derive.svg)](https://crates.io/crates/ssh-derive)     | [![Documentation](https://docs.rs/ssh-derive/badge.svg)](https://docs.rs/ssh-derive)     | Custom derive support for `ssh-encoding`             |
 | `ssh‑encoding` | [![crates.io](https://img.shields.io/crates/v/ssh-encoding.svg)](https://crates.io/crates/ssh-encoding) | [![Documentation](https://docs.rs/ssh-encoding/badge.svg)](https://docs.rs/ssh-encoding) | Decoders and encoders for SSH protocol data types    |
 | `ssh‑key`      | [![crates.io](https://img.shields.io/crates/v/ssh-key.svg)](https://crates.io/crates/ssh-key)           | [![Documentation](https://docs.rs/ssh-key/badge.svg)](https://docs.rs/ssh-key)           | SSH key and certificate library with signing support |
 

--- a/ssh-derive/CHANGELOG.md
+++ b/ssh-derive/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/ssh-derive/Cargo.toml
+++ b/ssh-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ssh-derive"
+version = "0.0.0"
+description = "Custom derive support for the `ssh-encoding` crate"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/RustCrypto/SSH/tree/master/ssh-derive"
+repository = "https://github.com/RustCrypto/SSH"
+categories = ["authentication", "cryptography", "encoding", "no-std", "parser-implementations"]
+keywords = ["crypto", "certificate", "key", "openssh", "ssh"]
+readme = "README.md"
+edition = "2021"
+rust-version = "1.60"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["extra-traits"] }

--- a/ssh-derive/LICENSE-APACHE
+++ b/ssh-derive/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ssh-derive/LICENSE-MIT
+++ b/ssh-derive/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2024 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ssh-derive/README.md
+++ b/ssh-derive/README.md
@@ -1,0 +1,54 @@
+# [RustCrypto]: Custom Derive for `ssh-encoding`
+
+[![crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
+![Apache2/MIT licensed][license-image]
+![Rust Version][rustc-image]
+[![Project Chat][chat-image]][chat-link]
+
+[Documentation][docs-link]
+
+## About
+
+Custom derive support for the `Decode` and `Encode` traits in the [`ssh-encoding`] crate.
+
+## Minimum Supported Rust Version
+
+This crate requires **Rust 1.60** at a minimum.
+
+We may change the MSRV in the future, but it will be accompanied by a minor
+version bump.
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[//]: # (badges)
+
+[crate-image]: https://buildstats.info/crate/ssh-derive
+[crate-link]: https://crates.io/crates/ssh-derive
+[docs-image]: https://docs.rs/ssh-derive/badge.svg
+[docs-link]: https://docs.rs/ssh-derive/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
+[chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
+[build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-derive.yml/badge.svg
+[build-link]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-derive.yml
+
+[//]: # (links)
+
+[RustCrypto]: https://github.com/rustcrypto
+[RFC4251]: https://datatracker.ietf.org/doc/html/rfc4251

--- a/ssh-derive/src/decode.rs
+++ b/ssh-derive/src/decode.rs
@@ -1,0 +1,91 @@
+//! Support for deriving the `Decode` trait on structs.
+
+use crate::FieldIr;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Generics, Ident};
+
+/// Derive the `Decode` trait for a struct
+pub(crate) struct DeriveDecode {
+    /// Name of the struct.
+    ident: Ident,
+
+    /// Generics of the struct.
+    generics: Generics,
+
+    /// Fields of the struct.
+    fields: Vec<FieldIr>,
+}
+
+impl DeriveDecode {
+    /// Parse [`DeriveInput`].
+    pub fn new(input: DeriveInput) -> syn::Result<Self> {
+        let data = match input.data {
+            syn::Data::Struct(data) => data,
+            _ => abort!(
+                input.ident,
+                "can't derive `Decode` on this type: only `struct` types are allowed",
+            ),
+        };
+
+        let fields = FieldIr::from_fields(data.fields)?;
+
+        Ok(Self {
+            ident: input.ident,
+            generics: input.generics.clone(),
+            fields,
+        })
+    }
+
+    /// Lower the derived output into a [`TokenStream`].
+    pub fn to_tokens(&self) -> TokenStream {
+        let ident = &self.ident;
+        let (_, generics, where_clause) = self.generics.split_for_impl();
+
+        let mut lowerer = FieldLowerer::new();
+        for field in &self.fields {
+            lowerer.add_field(field);
+        }
+        let body = lowerer.into_tokens();
+
+        quote! {
+            impl #generics ::ssh_encoding::Decode for #ident #generics #where_clause {
+                type Error = ::ssh_encoding::Error;
+
+                fn decode(reader: &mut impl Reader) -> Result<Self, Self::Error> {
+                    Ok(Self {
+                        #(#body)*,
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// AST lowerer for field decoders.
+struct FieldLowerer {
+    /// Decoder-in-progress.
+    body: Vec<TokenStream>,
+}
+
+impl FieldLowerer {
+    /// Create a new field decoder lowerer.
+    fn new() -> Self {
+        Self {
+            body: Vec::default(),
+        }
+    }
+
+    /// Add a field to the lowerer.
+    fn add_field(&mut self, field: &FieldIr) {
+        let ident = field.ident.clone();
+        let ty = field.ty.clone();
+        let field = quote! { #ident: #ty::decode()? };
+        self.body.push(field)
+    }
+
+    /// Return the resulting tokens.
+    fn into_tokens(self) -> Vec<TokenStream> {
+        self.body
+    }
+}

--- a/ssh-derive/src/decode/field.rs
+++ b/ssh-derive/src/decode/field.rs
@@ -1,0 +1,356 @@
+//! Sequence field IR and lowerings
+
+use crate::{Asn1Type, FieldAttrs, TagMode, TagNumber, TypeAttrs};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Field, Ident, Path, Type};
+
+/// "IR" for a field of a derived `Sequence`.
+pub(super) struct SequenceField {
+    /// Variant name.
+    pub(super) ident: Ident,
+
+    /// Field-level attributes.
+    pub(super) attrs: FieldAttrs,
+
+    /// Field type
+    pub(super) field_type: Type,
+}
+
+impl SequenceField {
+    /// Create a new [`SequenceField`] from the input [`Field`].
+    pub(super) fn new(field: &Field, type_attrs: &TypeAttrs) -> syn::Result<Self> {
+        let ident = field.ident.as_ref().cloned().ok_or_else(|| {
+            syn::Error::new_spanned(
+                field,
+                "no name on struct field i.e. tuple structs unsupported",
+            )
+        })?;
+
+        let attrs = FieldAttrs::parse(&field.attrs, type_attrs)?;
+
+        if attrs.asn1_type.is_some() && attrs.default.is_some() {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "ASN.1 `type` and `default` options cannot be combined",
+            ));
+        }
+
+        if attrs.default.is_some() && attrs.optional {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "`optional` and `default` field qualifiers are mutually exclusive",
+            ));
+        }
+
+        Ok(Self {
+            ident,
+            attrs,
+            field_type: field.ty.clone(),
+        })
+    }
+
+    /// Derive code for decoding a field of a sequence.
+    pub(super) fn to_decode_tokens(&self) -> TokenStream {
+        let mut lowerer = LowerFieldDecoder::new(&self.attrs);
+
+        if self.attrs.asn1_type.is_some() {
+            lowerer.apply_asn1_type(self.attrs.optional);
+        }
+
+        if let Some(default) = &self.attrs.default {
+            // TODO(tarcieri): default in conjunction with ASN.1 types?
+            debug_assert!(
+                self.attrs.asn1_type.is_none(),
+                "`type` and `default` are mutually exclusive"
+            );
+
+            // TODO(tarcieri): support for context-specific fields with defaults?
+            if self.attrs.context_specific.is_none() {
+                lowerer.apply_default(default, &self.field_type);
+            }
+        }
+
+        lowerer.into_tokens(&self.ident)
+    }
+
+    /// Derive code for encoding a field of a sequence.
+    pub(super) fn to_encode_tokens(&self) -> TokenStream {
+        let mut lowerer = LowerFieldEncoder::new(&self.ident);
+        let attrs = &self.attrs;
+
+        if let Some(ty) = &attrs.asn1_type {
+            // TODO(tarcieri): default in conjunction with ASN.1 types?
+            debug_assert!(
+                attrs.default.is_none(),
+                "`type` and `default` are mutually exclusive"
+            );
+            lowerer.apply_asn1_type(ty, attrs.optional);
+        }
+
+        if let Some(tag_number) = &attrs.context_specific {
+            lowerer.apply_context_specific(tag_number, &attrs.tag_mode, attrs.optional);
+        }
+
+        if let Some(default) = &attrs.default {
+            debug_assert!(
+                !attrs.optional,
+                "`default`, and `optional` are mutually exclusive"
+            );
+            lowerer.apply_default(&self.ident, default);
+        }
+
+        lowerer.into_tokens()
+    }
+}
+
+/// AST lowerer for field decoders.
+struct LowerFieldDecoder {
+    /// Decoder-in-progress.
+    decoder: TokenStream,
+}
+
+impl LowerFieldDecoder {
+    /// Create a new field decoder lowerer.
+    fn new(attrs: &FieldAttrs) -> Self {
+        Self {
+            decoder: attrs.decoder(),
+        }
+    }
+
+    ///  the field decoder to tokens.
+    fn into_tokens(self, ident: &Ident) -> TokenStream {
+        let decoder = self.decoder;
+
+        quote! {
+            let #ident = #decoder;
+        }
+    }
+
+    /// Apply the ASN.1 type (if defined).
+    fn apply_asn1_type(&mut self, optional: bool) {
+        let decoder = &self.decoder;
+
+        self.decoder = if optional {
+            quote! {
+                #decoder.map(TryInto::try_into).transpose()?
+            }
+        } else {
+            quote! {
+                #decoder.try_into()?
+            }
+        }
+    }
+
+    /// Handle default value for a type.
+    fn apply_default(&mut self, default: &Path, field_type: &Type) {
+        self.decoder = quote! {
+            Option::<#field_type>::decode(reader)?.unwrap_or_else(#default);
+        };
+    }
+}
+
+/// AST lowerer for field encoders.
+struct LowerFieldEncoder {
+    /// Encoder-in-progress.
+    encoder: TokenStream,
+}
+
+impl LowerFieldEncoder {
+    /// Create a new field encoder lowerer.
+    fn new(ident: &Ident) -> Self {
+        Self {
+            encoder: quote!(self.#ident),
+        }
+    }
+
+    ///  the field encoder to tokens.
+    fn into_tokens(self) -> TokenStream {
+        self.encoder
+    }
+
+    /// Apply the ASN.1 type (if defined).
+    fn apply_asn1_type(&mut self, asn1_type: &Asn1Type, optional: bool) {
+        let binding = &self.encoder;
+
+        self.encoder = if optional {
+            let map_arg = quote!(field);
+            let encoder = asn1_type.encoder(&map_arg);
+
+            quote! {
+                #binding.as_ref().map(|#map_arg| {
+                    der::Result::Ok(#encoder)
+                }).transpose()?
+            }
+        } else {
+            let encoder = asn1_type.encoder(binding);
+            quote!(#encoder)
+        };
+    }
+
+    /// Handle default value for a type.
+    fn apply_default(&mut self, ident: &Ident, default: &Path) {
+        let encoder = &self.encoder;
+
+        self.encoder = quote! {
+            if &self.#ident == &#default() {
+                None
+            } else {
+                Some(#encoder)
+            }
+        };
+    }
+
+    /// Make this field context-specific.
+    fn apply_context_specific(
+        &mut self,
+        tag_number: &TagNumber,
+        tag_mode: &TagMode,
+        optional: bool,
+    ) {
+        let encoder = &self.encoder;
+        let number_tokens = tag_number.to_tokens();
+        let mode_tokens = tag_mode.to_tokens();
+
+        if optional {
+            self.encoder = quote! {
+                #encoder.as_ref().map(|field| {
+                    ::der::asn1::ContextSpecificRef {
+                        tag_number: #number_tokens,
+                        tag_mode: #mode_tokens,
+                        value: field,
+                    }
+                })
+            };
+        } else {
+            self.encoder = quote! {
+                ::der::asn1::ContextSpecificRef {
+                    tag_number: #number_tokens,
+                    tag_mode: #mode_tokens,
+                    value: &#encoder,
+                }
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SequenceField;
+    use crate::{FieldAttrs, TagMode, TagNumber};
+    use proc_macro2::Span;
+    use quote::quote;
+    use syn::{punctuated::Punctuated, Ident, Path, PathSegment, Type, TypePath};
+
+    /// Create a [`Type::Path`].
+    pub fn type_path(ident: Ident) -> Type {
+        let mut segments = Punctuated::new();
+        segments.push_value(PathSegment {
+            ident,
+            arguments: Default::default(),
+        });
+
+        Type::Path(TypePath {
+            qself: None,
+            path: Path {
+                leading_colon: None,
+                segments,
+            },
+        })
+    }
+
+    #[test]
+    fn simple() {
+        let span = Span::call_site();
+        let ident = Ident::new("example_field", span);
+
+        let attrs = FieldAttrs {
+            asn1_type: None,
+            context_specific: None,
+            default: None,
+            extensible: false,
+            optional: false,
+            tag_mode: TagMode::Explicit,
+            constructed: false,
+        };
+
+        let field_type = Ident::new("String", span);
+
+        let field = SequenceField {
+            ident,
+            attrs,
+            field_type: type_path(field_type),
+        };
+
+        assert_eq!(
+            field.to_decode_tokens().to_string(),
+            quote! {
+                let example_field = reader.decode()?;
+            }
+            .to_string()
+        );
+
+        assert_eq!(
+            field.to_encode_tokens().to_string(),
+            quote! {
+                self.example_field
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn implicit() {
+        let span = Span::call_site();
+        let ident = Ident::new("implicit_field", span);
+
+        let attrs = FieldAttrs {
+            asn1_type: None,
+            context_specific: Some(TagNumber(0)),
+            default: None,
+            extensible: false,
+            optional: false,
+            tag_mode: TagMode::Implicit,
+            constructed: false,
+        };
+
+        let field_type = Ident::new("String", span);
+
+        let field = SequenceField {
+            ident,
+            attrs,
+            field_type: type_path(field_type),
+        };
+
+        assert_eq!(
+            field.to_decode_tokens().to_string(),
+            quote! {
+                let implicit_field = ::der::asn1::ContextSpecific::<>::decode_implicit(
+                        reader,
+                        ::der::TagNumber::N0
+                    )?
+                    .ok_or_else(|| {
+                        der::Tag::ContextSpecific {
+                            number: ::der::TagNumber::N0,
+                            constructed: false
+                        }
+                        .value_error()
+                    })?
+                    .value;
+            }
+            .to_string()
+        );
+
+        assert_eq!(
+            field.to_encode_tokens().to_string(),
+            quote! {
+                ::der::asn1::ContextSpecificRef {
+                    tag_number: ::der::TagNumber::N0,
+                    tag_mode: ::der::TagMode::Implicit,
+                    value: &self.implicit_field,
+                }
+            }
+            .to_string()
+        );
+    }
+}

--- a/ssh-derive/src/encode.rs
+++ b/ssh-derive/src/encode.rs
@@ -1,0 +1,102 @@
+//! Support for deriving the `Encode` trait on structs.
+
+use crate::FieldIr;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Generics, Ident};
+
+/// Derive the `Encode` trait for a struct
+pub(crate) struct DeriveEncode {
+    /// Name of the struct.
+    ident: Ident,
+
+    /// Generics of the struct.
+    generics: Generics,
+
+    /// Fields of the struct.
+    fields: Vec<FieldIr>,
+}
+
+impl DeriveEncode {
+    /// Parse [`DeriveInput`].
+    pub fn new(input: DeriveInput) -> syn::Result<Self> {
+        let data = match input.data {
+            syn::Data::Struct(data) => data,
+            _ => abort!(
+                input.ident,
+                "can't derive `Encode` on this type: only `struct` types are allowed",
+            ),
+        };
+
+        let fields = FieldIr::from_fields(data.fields)?;
+
+        Ok(Self {
+            ident: input.ident,
+            generics: input.generics.clone(),
+            fields,
+        })
+    }
+
+    /// Lower the derived output into a [`TokenStream`].
+    pub fn to_tokens(&self) -> TokenStream {
+        let ident = &self.ident;
+        let (_, generics, where_clause) = self.generics.split_for_impl();
+
+        let mut lowerer = FieldLowerer::new();
+        for field in &self.fields {
+            lowerer.add_field(field);
+        }
+        let (encoded_len_body, encode_body) = lowerer.into_tokens();
+
+        quote! {
+            impl #generics ::ssh_encoding::Encode for #ident #generics #where_clause {
+                fn encoded_len(&self) -> ssh_encoding::Result<usize> {
+                    [
+                        #(#encoded_len_body)*,
+                    ]
+                    .checked_sum()
+                }
+
+                fn encode(&self, writer: &mut impl Writer) -> ssh_encoding::Result<()> {
+                    #(#encode_body)*;
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+/// AST lowerer for field decoders.
+struct FieldLowerer {
+    /// Encoded length calculation in progress.
+    encoded_len_body: Vec<TokenStream>,
+
+    /// Encoder-in-progress.
+    encode_body: Vec<TokenStream>,
+}
+
+impl FieldLowerer {
+    /// Create a new field decoder lowerer.
+    fn new() -> Self {
+        Self {
+            encoded_len_body: Vec::default(),
+            encode_body: Vec::default(),
+        }
+    }
+
+    /// Add a field to the lowerer.
+    fn add_field(&mut self, field: &FieldIr) {
+        let ident = field.ident.clone();
+
+        let field_length = quote! { self.#ident.encoded_len()? };
+        self.encoded_len_body.push(field_length);
+
+        let field_encoder = quote! { self.#ident.encode()? };
+        self.encode_body.push(field_encoder);
+    }
+
+    /// Return the resulting tokens.
+    fn into_tokens(self) -> (Vec<TokenStream>, Vec<TokenStream>) {
+        (self.encoded_len_body, self.encode_body)
+    }
+}

--- a/ssh-derive/src/field_ir.rs
+++ b/ssh-derive/src/field_ir.rs
@@ -1,0 +1,31 @@
+use syn::{Field, Fields, Ident, Type};
+
+/// Intermediate representation for a struct field.
+pub(crate) struct FieldIr {
+    /// Field name.
+    pub ident: Ident,
+
+    /// Field type.
+    pub ty: Type,
+}
+
+impl FieldIr {
+    pub fn from_fields(fields: Fields) -> syn::Result<Vec<Self>> {
+        fields.iter().map(FieldIr::new).collect()
+    }
+
+    /// Create a new [`FieldIr`] from the input [`Field`].
+    pub fn new(field: &Field) -> syn::Result<Self> {
+        let ident = field.ident.as_ref().cloned().ok_or_else(|| {
+            syn::Error::new_spanned(
+                field,
+                "no name on struct field i.e. tuple structs unsupported",
+            )
+        })?;
+
+        Ok(Self {
+            ident,
+            ty: field.ty.clone(),
+        })
+    }
+}

--- a/ssh-derive/src/lib.rs
+++ b/ssh-derive/src/lib.rs
@@ -1,0 +1,57 @@
+#![doc = include_str!("../README.md")]
+
+//! ## About
+//! Custom derive support for the [`ssh-encoding`] crate.
+//!
+//! Note that this crate shouldn't be used directly, but instead accessed
+//! by using the `derive` feature of the `der` crate, which re-exports this crate's
+//! macros from the toplevel.
+//!
+//! [`ssh-encoding`]: ../ssh-encoding
+
+#![crate_type = "proc-macro"]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::unwrap_used,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_qualifications
+)]
+
+macro_rules! abort {
+    ( $tokens:expr, $message:expr $(,)? ) => {
+        return Err(syn::Error::new_spanned($tokens, $message))
+    };
+}
+
+mod decode;
+mod encode;
+mod field_ir;
+
+use crate::{decode::DeriveDecode, encode::DeriveEncode, field_ir::FieldIr};
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+/// Derive the [`Decode`][1] trait on a `struct`.
+///
+/// [1]: https://docs.rs/ssh-derive/latest/ssh-derive/trait.Decode.html
+#[proc_macro_derive(Decode, attributes(ssh))]
+pub fn derive_decode(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match DeriveDecode::new(input) {
+        Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Derive the [`Encode`][1] trait on a `struct`.
+///
+/// [1]: https://docs.rs/ssh-derive/latest/ssh-derive/trait.Encode.html
+#[proc_macro_derive(Encode, attributes(ssh))]
+pub fn derive_encode(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match DeriveEncode::new(input) {
+        Ok(t) => t.to_tokens().into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}


### PR DESCRIPTION
Adds a basic implementation with support for deriving the `Decode` and `Encode` traits.