### PR TITLE
ssh-cipher: bump `chacha20`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chacha20"
 version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/stream-ciphers.git#fea3dd013ee9c35fba56903ad44b411957de8cb2"
+source = "git+https://github.com/RustCrypto/stream-ciphers.git#299b27d618f925762974e1594e3dd2c4534f9940"
 dependencies = [
  "cfg-if",
  "cipher",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -27,7 +27,7 @@ aes = { version = "=0.9.0-pre", optional = true, default-features = false }
 aes-gcm = { version = "=0.11.0-pre", optional = true, default-features = false, features = ["aes"] }
 cbc = { version = "=0.2.0-pre", optional = true }
 ctr = { version = "=0.10.0-pre", optional = true, default-features = false }
-chacha20 = { version = "=0.10.0-pre", optional = true, default-features = false }
+chacha20 = { version = "=0.10.0-pre", optional = true, default-features = false, features = ["cipher"] }
 des = { version = "=0.9.0-pre.0", optional = true, default-features = false }
 poly1305 = { version = "=0.9.0-pre", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }


### PR DESCRIPTION
Updates the `chacha20` to the latest release from git, which now adds a `cipher` feature that needs to be enabled when using `default-features = false`