### PR TITLE
Cargo.lock: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/AEADs.git#d812daa6ef9cfe2ad15b8912dc63b978999c815d"
+source = "git+https://github.com/RustCrypto/AEADs.git#ad109f38b03124e7498bfe5e9830d1328f811d27"
 dependencies = [
  "aead",
  "aes",
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -56,7 +56,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bcrypt-pbkdf"
 version = "0.11.0-pre.0"
-source = "git+https://github.com/RustCrypto/password-hashes.git#cf91c17c93f57acfd3f547ecd697f86f8c271ba2"
+source = "git+https://github.com/RustCrypto/password-hashes.git#b06febccf09142840624c34129505436f83e5bd7"
 dependencies = [
  "blowfish",
  "pbkdf2",
@@ -84,7 +84,7 @@ dependencies = [
 [[package]]
 name = "blowfish"
 version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#d6ed7a2f45f53db013824ac0e91419fc4f8a4321"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#ae1892c8600131227531504812260e3d2821d01e"
 dependencies = [
  "byteorder",
  "cipher",
@@ -98,14 +98,14 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cbc"
 version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/block-modes.git#a2d538114e74ca85c19b6173d08e5aa519763778"
+source = "git+https://github.com/RustCrypto/block-modes.git#a0051b2892626f4bd4f96c8ec7ca942a1047bb3c"
 dependencies = [
  "cipher",
 ]
@@ -144,9 +144,9 @@ checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "ctr"
 version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/block-modes.git#a2d538114e74ca85c19b6173d08e5aa519763778"
+source = "git+https://github.com/RustCrypto/block-modes.git#a0051b2892626f4bd4f96c8ec7ca942a1047bb3c"
 dependencies = [
  "cipher",
 ]
@@ -210,7 +210,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.8.0-pre.0"
-source = "git+https://github.com/RustCrypto/formats.git#c03c06640e2499db947f7d02789fa6f3dde07340"
+source = "git+https://github.com/RustCrypto/formats.git#d32a61ea61d44152ce17380964d233b439ce603a"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "dsa"
 version = "0.7.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#11ea63809073d9bf2ecdb4242bc030bec7ab532f"
+source = "git+https://github.com/RustCrypto/signatures.git#62419f8b10319e2992765f153e1042fa5871c1f3"
 dependencies = [
  "digest",
  "num-bigint-dig",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "ecdsa"
 version = "0.17.0-pre.5"
-source = "git+https://github.com/RustCrypto/signatures.git#11ea63809073d9bf2ecdb4242bc030bec7ab532f"
+source = "git+https://github.com/RustCrypto/signatures.git#62419f8b10319e2992765f153e1042fa5871c1f3"
 dependencies = [
  "der",
  "digest",
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "ed25519"
 version = "2.3.0-pre"
-source = "git+https://github.com/RustCrypto/signatures.git#11ea63809073d9bf2ecdb4242bc030bec7ab532f"
+source = "git+https://github.com/RustCrypto/signatures.git#62419f8b10319e2992765f153e1042fa5871c1f3"
 dependencies = [
  "signature",
 ]
@@ -315,15 +315,15 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -388,18 +388,18 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -426,19 +426,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -447,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -457,14 +456,14 @@ dependencies = [
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p256"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d8632ea9970aa583c89e944356b8bc8d1"
+source = "git+https://github.com/RustCrypto/elliptic-curves.git#e6ea0bdc6b2d09cdf72aba901217c21684ed7e72"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -475,7 +474,7 @@ dependencies = [
 [[package]]
 name = "p384"
 version = "0.14.0-pre"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d8632ea9970aa583c89e944356b8bc8d1"
+source = "git+https://github.com/RustCrypto/elliptic-curves.git#e6ea0bdc6b2d09cdf72aba901217c21684ed7e72"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -486,7 +485,7 @@ dependencies = [
 [[package]]
 name = "p521"
 version = "0.14.0-pre"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d8632ea9970aa583c89e944356b8bc8d1"
+source = "git+https://github.com/RustCrypto/elliptic-curves.git#e6ea0bdc6b2d09cdf72aba901217c21684ed7e72"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -499,7 +498,7 @@ dependencies = [
 [[package]]
 name = "pbkdf2"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/RustCrypto/password-hashes.git#cf91c17c93f57acfd3f547ecd697f86f8c271ba2"
+source = "git+https://github.com/RustCrypto/password-hashes.git#b06febccf09142840624c34129505436f83e5bd7"
 dependencies = [
  "digest",
 ]
@@ -516,7 +515,7 @@ dependencies = [
 [[package]]
 name = "pkcs1"
 version = "0.8.0-pre.0"
-source = "git+https://github.com/RustCrypto/formats.git#c03c06640e2499db947f7d02789fa6f3dde07340"
+source = "git+https://github.com/RustCrypto/formats.git#d32a61ea61d44152ce17380964d233b439ce603a"
 dependencies = [
  "der",
  "pkcs8",
@@ -526,7 +525,7 @@ dependencies = [
 [[package]]
 name = "pkcs8"
 version = "0.11.0-pre.0"
-source = "git+https://github.com/RustCrypto/formats.git#c03c06640e2499db947f7d02789fa6f3dde07340"
+source = "git+https://github.com/RustCrypto/formats.git#d32a61ea61d44152ce17380964d233b439ce603a"
 dependencies = [
  "der",
  "spki",
@@ -564,12 +563,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primefield"
 version = "0.14.0-pre"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d8632ea9970aa583c89e944356b8bc8d1"
+source = "git+https://github.com/RustCrypto/elliptic-curves.git#e6ea0bdc6b2d09cdf72aba901217c21684ed7e72"
 
 [[package]]
 name = "primeorder"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d8632ea9970aa583c89e944356b8bc8d1"
+source = "git+https://github.com/RustCrypto/elliptic-curves.git#e6ea0bdc6b2d09cdf72aba901217c21684ed7e72"
 dependencies = [
  "elliptic-curve",
 ]
@@ -624,7 +623,7 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.5.0-pre.3"
-source = "git+https://github.com/RustCrypto/signatures.git#11ea63809073d9bf2ecdb4242bc030bec7ab532f"
+source = "git+https://github.com/RustCrypto/signatures.git#62419f8b10319e2992765f153e1042fa5871c1f3"
 dependencies = [
  "hmac",
  "subtle",
@@ -663,7 +662,7 @@ dependencies = [
 [[package]]
 name = "sec1"
 version = "0.8.0-pre.1"
-source = "git+https://github.com/RustCrypto/formats.git#c03c06640e2499db947f7d02789fa6f3dde07340"
+source = "git+https://github.com/RustCrypto/formats.git#d32a61ea61d44152ce17380964d233b439ce603a"
 dependencies = [
  "base16ct",
  "der",
@@ -675,24 +674,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -733,20 +732,20 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
 version = "0.8.0-pre.0"
-source = "git+https://github.com/RustCrypto/formats.git#c03c06640e2499db947f7d02789fa6f3dde07340"
+source = "git+https://github.com/RustCrypto/formats.git#d32a61ea61d44152ce17380964d233b439ce603a"
 dependencies = [
  "base64ct",
  "der",


### PR DESCRIPTION
Updates the following dependencies:

    $ cargo update
    Updating git repository `https://github.com/RustCrypto/AEADs.git`
    Updating git repository `https://github.com/RustCrypto/password-hashes.git`
    Updating git repository `https://github.com/RustCrypto/block-ciphers.git`
    Updating git repository `https://github.com/RustCrypto/block-modes.git`
    Updating git repository `https://github.com/RustCrypto/stream-ciphers.git`
    Updating git repository `https://github.com/RustCrypto/formats.git`
    Updating git repository `https://github.com/RustCrypto/signatures.git`
    Updating git repository `https://github.com/baloo/curve25519-dalek.git`
    Updating git repository `https://github.com/RustCrypto/elliptic-curves.git`
    Updating crates.io index
     Locking 39 packages to latest compatible versions
    Updating aes-gcm v0.11.0-pre (https://github.com/RustCrypto/AEADs.git#d812daa6) -> #ad109f38
    Updating autocfg v1.1.0 -> v1.3.0
    Updating bcrypt-pbkdf v0.11.0-pre.0 (https://github.com/RustCrypto/password-hashes.git#cf91c17c) -> #b06febcc
    Updating blowfish v0.10.0-pre (https://github.com/RustCrypto/block-ciphers.git#d6ed7a2f) -> #ae1892c8
    Updating bytes v1.6.0 -> v1.6.1
    Updating cbc v0.2.0-pre (https://github.com/RustCrypto/block-modes.git#a2d53811) -> #a0051b28
    Updating cpufeatures v0.2.11 -> v0.2.12
    Updating ctr v0.10.0-pre (https://github.com/RustCrypto/block-modes.git#a2d53811) -> #a0051b28
    Updating der v0.8.0-pre.0 (https://github.com/RustCrypto/formats.git#c03c0664) -> #d32a61ea
    Updating dsa v0.7.0-pre (https://github.com/RustCrypto/signatures.git#11ea6380) -> #62419f8b
    Updating ecdsa v0.17.0-pre.5 (https://github.com/RustCrypto/signatures.git#11ea6380) -> #62419f8b
    Updating ed25519 v2.3.0-pre (https://github.com/RustCrypto/signatures.git#11ea6380) -> #62419f8b
    Updating fiat-crypto v0.2.5 -> v0.2.9
    Updating getrandom v0.2.11 -> v0.2.15
    Updating lazy_static v1.4.0 -> v1.5.0
    Updating libc v0.2.150 -> v0.2.155
    Updating num-integer v0.1.45 -> v0.1.46
    Updating num-iter v0.1.43 -> v0.1.45
    Updating num-traits v0.2.17 -> v0.2.19
    Updating opaque-debug v0.3.0 -> v0.3.1
    Updating p256 v0.14.0-pre.0 (https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d) -> #e6ea0bdc
    Updating p384 v0.14.0-pre (https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d) -> #e6ea0bdc
    Updating p521 v0.14.0-pre (https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d) -> #e6ea0bdc
    Updating pbkdf2 v0.13.0-pre.0 (https://github.com/RustCrypto/password-hashes.git#cf91c17c) -> #b06febcc
    Updating pkcs1 v0.8.0-pre.0 (https://github.com/RustCrypto/formats.git#c03c0664) -> #d32a61ea
    Updating pkcs8 v0.11.0-pre.0 (https://github.com/RustCrypto/formats.git#c03c0664) -> #d32a61ea
    Updating primefield v0.14.0-pre (https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d) -> #e6ea0bdc
    Updating primeorder v0.14.0-pre.0 (https://github.com/RustCrypto/elliptic-curves.git#6ff3bb7d) -> #e6ea0bdc
    Updating proc-macro2 v1.0.69 -> v1.0.86
    Updating quote v1.0.33 -> v1.0.36
    Updating rfc6979 v0.5.0-pre.3 (https://github.com/RustCrypto/signatures.git#11ea6380) -> #62419f8b
    Updating sec1 v0.8.0-pre.1 (https://github.com/RustCrypto/formats.git#c03c0664) -> #d32a61ea
    Updating semver v1.0.20 -> v1.0.23
    Updating serde v1.0.192 -> v1.0.204
    Updating serde_derive v1.0.192 -> v1.0.204
    Updating smallvec v1.11.2 -> v1.13.2
    Updating spin v0.5.2 -> v0.9.8
    Updating spki v0.8.0-pre.0 (https://github.com/RustCrypto/formats.git#c03c0664) -> #d32a61ea
    Updating syn v2.0.39 -> v2.0.71