### PR TITLE
Publish `pre.0` prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-cipher"
-version = "0.3.0-pre"
+version = "0.3.0-pre.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-encoding"
-version = "0.3.0-pre"
+version = "0.3.0-pre.0"
 dependencies = [
  "base64ct",
  "bytes",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.7.0-pre"
+version = "0.7.0-pre.0"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-protocol"
-version = "0.1.0-pre"
+version = "0.1.0-pre.0"
 dependencies = [
  "ssh-cipher",
  "ssh-encoding",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-cipher"
-version = "0.3.0-pre"
+version = "0.3.0-pre.0"
 description = """
 Pure Rust implementation of SSH symmetric encryption including support for the
 modern aes128-gcm@openssh.com/aes256-gcm@openssh.com and
@@ -20,7 +20,7 @@ rust-version = "1.72"
 
 [dependencies]
 cipher = "=0.5.0-pre.6"
-encoding = { package = "ssh-encoding", version = "=0.3.0-pre", path = "../ssh-encoding" }
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre.0", path = "../ssh-encoding" }
 
 # optional dependencies
 aes = { version = "=0.9.0-pre.1", optional = true, default-features = false }

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-encoding"
-version = "0.3.0-pre"
+version = "0.3.0-pre.0"
 description = """
 Pure Rust implementation of SSH data type decoders/encoders as described
 in RFC4251

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.7.0-pre"
+version = "0.7.0-pre.0"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and
@@ -18,8 +18,8 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-cipher = { package = "ssh-cipher", version = "=0.3.0-pre", path = "../ssh-cipher" }
-encoding = { package = "ssh-encoding", version = "=0.3.0-pre", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
+cipher = { package = "ssh-cipher", version = "=0.3.0-pre.0", path = "../ssh-cipher" }
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre.0", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 signature = { version = "=2.3.0-pre.4", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/ssh-protocol/Cargo.toml
+++ b/ssh-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-protocol"
-version = "0.1.0-pre"
+version = "0.1.0-pre.0"
 description = """
 Pure Rust implementation of the SSH protocol as described in RFC4251/RFC4253 as well as
 OpenSSH-specific extensions (WIP)
@@ -16,9 +16,9 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-cipher = { package = "ssh-cipher", version = "=0.3.0-pre", default-features = false, path = "../ssh-cipher" }
-encoding = { package = "ssh-encoding", version = "=0.3.0-pre", default-features = false, path = "../ssh-encoding" }
-key = { package = "ssh-key", version = "=0.7.0-pre", default-features = false, path = "../ssh-key" }
+cipher = { package = "ssh-cipher", version = "=0.3.0-pre.0", default-features = false, path = "../ssh-cipher" }
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre.0", default-features = false, path = "../ssh-encoding" }
+key = { package = "ssh-key", version = "=0.7.0-pre.0", default-features = false, path = "../ssh-key" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Publishes an initial set of prereleases of the following crates:

- `ssh-cipher` v0.3.0-pre.0
- `ssh-encoding` v0.3.0-pre.0
- `ssh-key` v0.7.0-pre.0
- `ssh-protocol` v0.1.0-pre.0