### PR TITLE
Revert "ssh-key: temporarily remove `ed25519` feature (#249)"

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -72,7 +72,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,dsa,getrandom,p256,p384,p521,rsa,tdes,std --release # ed25519
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std --release
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features alloc,crypto,dsa,encryption,tdes --release
 
   test:
@@ -88,7 +88,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --exclude-features default,dsa,getrandom,p256,p384,p521,rsa,tdes,std --release # ed25519
+      - run: cargo hack test --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std --release
       - run: cargo test --release
       - run: cargo test --release --features getrandom
       - run: cargo test --release --features std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?branch=rustcrypto-new-releases#44508ba8652ae3445608ad3c56b63ef528ddfb93"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?branch=rustcrypto-new-releases#44508ba8652ae3445608ad3c56b63ef528ddfb93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +275,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bcc0730fbd27c8619332efad3dfa1de229dc5859a31495ab674e0ac0f9996b"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0-pre"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?branch=rustcrypto-new-releases#44508ba8652ae3445608ad3c56b63ef528ddfb93"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "elliptic-curve"
 version = "0.14.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +322,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "getrandom"
@@ -620,6 +670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "sec1"
 version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +691,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -749,6 +814,7 @@ version = "0.7.0-pre.0"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",
+ "ed25519-dalek",
  "hex-literal",
  "num-bigint-dig",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ opt-level = 2
 
 [patch.crates-io]
 # https://github.com/dalek-cryptography/curve25519-dalek/pull/676
-#ed25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", branch = "rustcrypto-new-releases" }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", branch = "rustcrypto-new-releases" }

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false }
 bcrypt-pbkdf = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["alloc"] }
 bigint = { package = "num-bigint-dig", version = "0.8", optional = true, default-features = false }
 dsa = { version = "=0.7.0-pre.0", optional = true, default-features = false }
-#ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
+ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
 p256 = { version = "=0.14.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "=0.14.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
 p521 = { version = "=0.14.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
@@ -61,10 +61,10 @@ std = [
     "signature/std"
 ]
 
-crypto = ["p256", "p384", "p521", "rsa"] # ... "ed25519"] NOTE: `dsa` is obsolete/weak
+crypto = ["ed25519", "p256", "p384", "p521", "rsa"] # NOTE: `dsa` is obsolete/weak
 dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand_core"]
 ecdsa = ["dep:sec1"]
-#ed25519 = ["dep:ed25519-dalek", "rand_core"]
+ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [
     "dep:bcrypt-pbkdf",
     "alloc",

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -5,7 +5,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 #![forbid(unsafe_code)]
 #![warn(
     clippy::alloc_instead_of_core,

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -1,7 +1,6 @@
 //! OpenSSH certificate tests.
 
 #![cfg(feature = "alloc")]
-#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 
 use hex_literal::hex;
 use ssh_key::{Algorithm, Certificate};

--- a/ssh-key/tests/certificate_builder.rs
+++ b/ssh-key/tests/certificate_builder.rs
@@ -1,6 +1,5 @@
 //! Certificate builder tests.
 
-#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 #![cfg(all(
     feature = "alloc",
     feature = "rand_core",

--- a/ssh-key/tests/sshsig.rs
+++ b/ssh-key/tests/sshsig.rs
@@ -1,7 +1,6 @@
 //! `sshsig` signature tests.
 
 #![cfg(feature = "alloc")]
-#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 
 use hex_literal::hex;
 use ssh_key::{Algorithm, HashAlg, LineEnding, PublicKey, SshSig};


### PR DESCRIPTION
This reverts commit d52ad0b6f81458c21192ede8c2ad14f97bbb3b3e.

Now that we've cut a set of prereleaes (#250) we can add the `ed25519` feature back.