### PR TITLE
ssh-cipher: make `ChaCha20Poly1305` public

### DIFF
--- a/ssh-cipher/src/lib.rs
+++ b/ssh-cipher/src/lib.rs
@@ -35,6 +35,9 @@ mod encryptor;
 
 pub use crate::error::{Error, Result};
 
+#[cfg(feature = "chacha20poly1305")]
+pub use crate::chacha20poly1305::ChaCha20Poly1305;
+
 #[cfg(any(feature = "aes-cbc", feature = "aes-ctr", feature = "tdes"))]
 pub use crate::{decryptor::Decryptor, encryptor::Encryptor};
 
@@ -43,9 +46,6 @@ use encoding::{Label, LabelError};
 
 #[cfg(feature = "aes-gcm")]
 use aes_gcm::{aead::AeadInPlace, Aes128Gcm, Aes256Gcm};
-
-#[cfg(feature = "chacha20poly1305")]
-use crate::chacha20poly1305::ChaCha20Poly1305;
 
 #[cfg(feature = "aes-gcm")]
 use cipher::KeyInit;


### PR DESCRIPTION
Directly exposes the `ChaCha20Poly1305` type implementing the `chacha20-poly1305@openssh.com` variant (which is different from the NaCl/libsodium "djb" variant as well as the IETF variant of ChaCha20Poly1305).

Also improves documentation to help clarify its nature.