### PR TITLE
ssh-key: add `DotSsh::{write_private_key, write_public_key}`

### DIFF
--- a/ssh-key/src/dot_ssh.rs
+++ b/ssh-key/src/dot_ssh.rs
@@ -69,6 +69,16 @@ impl DotSsh {
             .ok()?
             .find(|key| key.fingerprint(fingerprint.algorithm()) == fingerprint)
     }
+
+    /// Write a private key into `~/.ssh`.
+    pub fn write_private_key(&self, filename: impl AsRef<Path>, key: &PrivateKey) -> Result<()> {
+        key.write_openssh_file(&self.path.join(filename), Default::default())
+    }
+
+    /// Write a public key into `~/.ssh`.
+    pub fn write_public_key(&self, filename: impl AsRef<Path>, key: &PublicKey) -> Result<()> {
+        key.write_openssh_file(&self.path.join(filename))
+    }
 }
 
 impl Default for DotSsh {


### PR DESCRIPTION
Adds helpers for writing private/public key files into `~/.ssh`