### PR TITLE
ssh-key: add `SshSig` serializing/deserializing using `serde`

### DIFF
--- a/ssh-key/src/sshsig.rs
+++ b/ssh-key/src/sshsig.rs
@@ -362,8 +362,7 @@ impl<'de> Deserialize<'de> for SshSig {
             string.parse::<SshSig>().map_err(de::Error::custom)
         } else {
             let bytes = Vec::<u8>::deserialize(deserializer)?;
-            let mut bytes_slice: &[u8] = &bytes;
-            Self::decode(&mut bytes_slice).map_err(de::Error::custom)
+            Self::decode(&mut bytes.as_slice()).map_err(de::Error::custom)
         }
     }
 }

--- a/ssh-key/src/sshsig.rs
+++ b/ssh-key/src/sshsig.rs
@@ -15,7 +15,6 @@ use crate::{PrivateKey, PublicKey};
 type Version = u32;
 
 #[cfg(feature = "serde")]
-use std::io::Cursor;
 use serde::{de, ser, Deserialize, Serialize};
 
 /// `sshsig` provides a general-purpose signature format based on SSH keys and
@@ -207,7 +206,6 @@ impl SshSig {
 
     /// Get the hash algorithm used to produce this signature.
 
-
     ///
     /// Data to be signed is first hashed with the specified `hash_alg`.
     /// This is done to limit the amount of data presented to the signature
@@ -367,7 +365,6 @@ impl<'de> Deserialize<'de> for SshSig {
             let mut bytes_slice: &[u8] = &bytes;
             Self::decode(&mut bytes_slice).map_err(de::Error::custom)
         }
-            
     }
 }
 

--- a/ssh-key/src/sshsig.rs
+++ b/ssh-key/src/sshsig.rs
@@ -367,6 +367,8 @@ impl Serialize for SshSig {
     where
         S: ser::Serializer,
     {
-        self.to_pem(LineEnding::LF).map_err(ser::Error::custom)?.serialize(serializer)
+        self.to_pem(LineEnding::LF)
+            .map_err(ser::Error::custom)?
+            .serialize(serializer)
     }
 }


### PR DESCRIPTION
Hello

I'm making a web server, which operates on SSH signatures, and I noticed that I could not include `SshSig` in my Serde Deserialized struct, so I had to parse it manually. So I decided to fork and add this functionality.

Cheers!