### PR TITLE
ssh-encoding: add `Encode::{encode_vec, encode_bytes}`

### DIFF
--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -10,7 +10,7 @@ use core::str;
 use alloc::{string::String, vec::Vec};
 
 #[cfg(feature = "bytes")]
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 /// Encoding trait.
 ///
@@ -33,6 +33,22 @@ pub trait Encode {
     fn encode_prefixed(&self, writer: &mut impl Writer) -> Result<(), Error> {
         self.encoded_len()?.encode(writer)?;
         self.encode(writer)
+    }
+
+    /// Encode this value, returning a `Vec<u8>` containing the encoded message.
+    #[cfg(feature = "alloc")]
+    fn encode_vec(&self) -> Result<Vec<u8>, Error> {
+        let mut ret = Vec::with_capacity(self.encoded_len()?);
+        self.encode(&mut ret)?;
+        Ok(ret)
+    }
+
+    /// Encode this value, returning a [`BytesMut`] containing the encoded message.
+    #[cfg(feature = "bytes")]
+    fn encode_bytes(&self) -> Result<BytesMut, Error> {
+        let mut ret = BytesMut::with_capacity(self.encoded_len()?);
+        self.encode(&mut ret)?;
+        Ok(ret)
     }
 }
 

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -54,5 +54,8 @@ pub use crate::{
 #[cfg(feature = "base64")]
 pub use crate::{base64::Base64Reader, base64::Base64Writer};
 
+#[cfg(feature = "bytes")]
+pub use bytes;
+
 #[cfg(feature = "pem")]
 pub use crate::pem::{DecodePem, EncodePem};

--- a/ssh-encoding/src/writer.rs
+++ b/ssh-encoding/src/writer.rs
@@ -5,6 +5,9 @@ use crate::Result;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+#[cfg(feature = "bytes")]
+use bytes::{BufMut, BytesMut};
+
 #[cfg(feature = "sha2")]
 use sha2::{Digest, Sha256, Sha512};
 
@@ -19,6 +22,14 @@ pub trait Writer: Sized {
 impl Writer for Vec<u8> {
     fn write(&mut self, bytes: &[u8]) -> Result<()> {
         self.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Writer for BytesMut {
+    fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        self.put(bytes);
         Ok(())
     }
 }


### PR DESCRIPTION
Adds convenience methods for producing a `Vec<u8>` or `BytesMut` from any type which impls `Encode`.