### PR TITLE
ssh-encoding: add `digest` feature; remove `sha2` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,6 @@ dependencies = [
  "digest",
  "hex-literal",
  "pem-rfc7468",
- "sha2",
 ]
 
 [[package]]

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -18,16 +18,15 @@ rust-version = "1.71"
 [dependencies]
 base64ct = { version = "1.4", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
+digest = { version = "=0.11.0-pre.9", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.1", optional = true }
-sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
-digest = { version = "=0.11.0-pre.9", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
 
 [features]
 alloc = ["base64ct?/alloc", "pem-rfc7468?/alloc"]
-std = ["alloc", "base64ct?/std", "pem-rfc7468?/std", "sha2?/std"]
+std = ["alloc", "base64ct?/std", "digest?/std", "pem-rfc7468?/std"]
 
 base64 = ["dep:base64ct"]
 bytes = ["alloc", "dep:bytes"]

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::{
     error::{Error, Result},
     label::{Label, LabelError},
     reader::Reader,
-    writer::{DigestWriter, Writer},
+    writer::Writer,
 };
 
 #[cfg(feature = "base64")]
@@ -56,6 +56,11 @@ pub use crate::{base64::Base64Reader, base64::Base64Writer};
 
 #[cfg(feature = "bytes")]
 pub use bytes;
+
+#[cfg(feature = "digest")]
+pub use crate::writer::DigestWriter;
+#[cfg(feature = "digest")]
+pub use digest;
 
 #[cfg(feature = "pem")]
 pub use crate::pem::{DecodePem, EncodePem};

--- a/ssh-encoding/src/writer.rs
+++ b/ssh-encoding/src/writer.rs
@@ -8,6 +8,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "bytes")]
 use bytes::{BufMut, BytesMut};
 
+#[cfg(feature = "digest")]
 use digest::Digest;
 
 /// Writer trait which encodes the SSH binary format to various output
@@ -36,9 +37,11 @@ impl Writer for BytesMut {
 /// Wrapper for digests.
 ///
 /// This allows to update digests from the serializer directly.
+#[cfg(feature = "digest")]
 #[derive(Debug)]
 pub struct DigestWriter<'d, D>(pub &'d mut D);
 
+#[cfg(feature = "digest")]
 impl<D> Writer for DigestWriter<'_, D>
 where
     D: Digest,

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.73"
 
 [dependencies]
 cipher = { package = "ssh-cipher", version = "=0.3.0-pre.0", path = "../ssh-cipher" }
-encoding = { package = "ssh-encoding", version = "=0.3.0-pre.0", features = ["base64", "pem", "sha2"], path = "../ssh-encoding" }
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre.0", features = ["base64", "digest", "pem"], path = "../ssh-encoding" }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 signature = { version = "=2.3.0-pre.4", default-features = false }
 subtle = { version = "2", default-features = false }


### PR DESCRIPTION
- Makes `digest` optional the same way `sha2` was optional
- `sha2` is no-longer used by `ssh-encoding`; generic around `digest`