### PR TITLE
ssh-cipher: refactor `ChaCha20Poly1305` to use `aead` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
 name = "ssh-cipher"
 version = "0.3.0-pre.0"
 dependencies = [
+ "aead",
  "aes",
  "aes-gcm",
  "cbc",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -23,11 +23,12 @@ cipher = "=0.5.0-pre.6"
 encoding = { package = "ssh-encoding", version = "=0.3.0-pre.0", path = "../ssh-encoding" }
 
 # optional dependencies
+aead = { version = "0.6.0-rc.0", optional = true, default-features = false }
 aes = { version = "=0.9.0-pre.1", optional = true, default-features = false }
 aes-gcm = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["aes"] }
 cbc = { version = "=0.2.0-pre.1", optional = true }
 ctr = { version = "=0.10.0-pre.1", optional = true, default-features = false }
-chacha20 = { version = "=0.10.0-pre.1", optional = true, default-features = false, features = ["cipher"] }
+chacha20 = { version = "=0.10.0-pre.1", optional = true, default-features = false, features = ["cipher", "legacy"] }
 des = { version = "=0.9.0-pre.1", optional = true, default-features = false }
 poly1305 = { version = "0.9.0-rc.0", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
@@ -37,8 +38,8 @@ std = []
 
 aes-cbc = ["dep:aes", "dep:cbc"]
 aes-ctr = ["dep:aes", "dep:ctr"]
-aes-gcm = ["dep:aes", "dep:aes-gcm"]
-chacha20poly1305 = ["dep:chacha20", "dep:poly1305", "dep:subtle"]
+aes-gcm = ["dep:aead", "dep:aes", "dep:aes-gcm"]
+chacha20poly1305 = ["dep:aead", "dep:chacha20", "dep:poly1305", "dep:subtle"]
 tdes = ["dep:des", "dep:cbc"]
 
 [package.metadata.docs.rs]

--- a/ssh-key/src/kdf.rs
+++ b/ssh-key/src/kdf.rs
@@ -100,7 +100,7 @@ impl Kdf {
         // key encryption, relying on a unique salt used in the password-based encryption key
         // derivation to ensure that each encryption key is only used once.
         if cipher == Cipher::ChaCha20Poly1305 {
-            iv.copy_from_slice(&cipher::Nonce::default());
+            iv.copy_from_slice(&cipher::ChaChaNonce::default());
         }
 
         Ok((okm, iv))


### PR DESCRIPTION
Changes the `ChaCha20Poly1305` type to impl the standard AEAD APIs exported by the `aead` crate.