### PR TITLE
ssh-cipher: add `zeroize` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -34,6 +35,7 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -129,6 +131,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -139,6 +142,7 @@ checksum = "c71c893d5a1e8257048dbb29954d2e1f85f091a150304f1defe4ca2806da5d3f"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -565,6 +569,7 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+ "zeroize",
 ]
 
 [[package]]
@@ -797,6 +802,7 @@ dependencies = [
  "poly1305",
  "ssh-encoding",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -32,6 +32,7 @@ chacha20 = { version = "=0.10.0-pre.1", optional = true, default-features = fals
 des = { version = "=0.9.0-pre.1", optional = true, default-features = false }
 poly1305 = { version = "0.9.0-rc.0", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -44,6 +45,14 @@ aes-ctr = ["dep:aes", "dep:ctr"]
 aes-gcm = ["dep:aead", "dep:aes", "dep:aes-gcm"]
 chacha20poly1305 = ["dep:aead", "dep:chacha20", "dep:poly1305", "dep:subtle"]
 tdes = ["dep:des", "dep:cbc"]
+zeroize = [
+    "dep:zeroize",
+    "aes?/zeroize",
+    "aes-gcm?/zeroize",
+    "chacha20?/zeroize",
+    "des?/zeroize",
+    "poly1305?/zeroize"
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 rust-version = "1.73"
 
 [dependencies]
-cipher = { package = "ssh-cipher", version = "=0.3.0-pre.2", path = "../ssh-cipher" }
+cipher = { package = "ssh-cipher", version = "=0.3.0-pre.2", features = ["zeroize"], path = "../ssh-cipher" }
 encoding = { package = "ssh-encoding", version = "=0.3.0-pre.1", features = ["base64", "digest", "pem"], path = "../ssh-encoding" }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 signature = { version = "=2.3.0-pre.4", default-features = false }


### PR DESCRIPTION
Adds a feature which transitively enables zeroization support in various dependencies.

`ssh-key` now activates it by default.