### PR TITLE
ssh-key: allow `AuthorizedKeys` comments to have spaces

### DIFF
--- a/ssh-key/src/authorized_keys.rs
+++ b/ssh-key/src/authorized_keys.rs
@@ -147,7 +147,7 @@ impl str::FromStr for Entry {
                 config_opts: Default::default(),
                 public_key: line.parse()?,
             }),
-            3 => line
+            3.. => line
                 .split_once(' ')
                 .map(|(config_opts_str, public_key_str)| {
                     ConfigOptsIter(config_opts_str).validate()?;


### PR DESCRIPTION
Treat 3 or more spaces the same. Comments start at the space and continue to the end of the line.

Closes #285 