### PR TITLE
ssh-key: accept undersized mpints in ECDSA signatures

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -519,6 +519,7 @@ impl_signature_for_curve!(p256, "p256", NistP256, 32);
 impl_signature_for_curve!(p384, "p384", NistP384, 48);
 impl_signature_for_curve!(p521, "p521", NistP521, 66);
 
+/// Build a generic sized object from a `u8` iterator, with leading zero padding
 #[cfg(any(feature = "p256", feature = "p384", feature = "p521"))]
 fn zero_pad_field_bytes<B: FromIterator<u8> + Copy>(m: Mpint) -> Option<B> {
     use core::mem::size_of;

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -13,7 +13,6 @@ use crate::{private::Ed25519Keypair, public::Ed25519PublicKey};
 use {
     crate::{private::DsaKeypair, public::DsaPublicKey},
     bigint::BigUint,
-    core::iter,
     sha1::Sha1,
     signature::{DigestSigner, DigestVerifier},
 };
@@ -23,6 +22,9 @@ use crate::{
     private::{EcdsaKeypair, EcdsaPrivateKey},
     public::EcdsaPublicKey,
 };
+
+#[cfg(any(feature = "dsa", feature = "p256", feature = "p384", feature = "p521"))]
+use core::iter;
 
 #[cfg(feature = "rsa")]
 use {
@@ -520,9 +522,10 @@ impl_signature_for_curve!(p521, "p521", NistP521, 66);
 #[cfg(any(feature = "p256", feature = "p384", feature = "p521"))]
 fn build_field_bytes<B: FromIterator<u8> + Copy>(m: Mpint) -> Option<B> {
     let bytes = m.as_positive_bytes()?;
-    std::mem::size_of::<B>()
+    #[allow(unused_qualifications)] // size_of is in the prelude of Rust > 1.80
+    core::mem::size_of::<B>()
         .checked_sub(bytes.len())
-        .map(|i| B::from_iter(std::iter::repeat(0u8).take(i).chain(bytes.iter().cloned())))
+        .map(|i| B::from_iter(iter::repeat(0u8).take(i).chain(bytes.iter().cloned())))
 }
 
 #[cfg(feature = "p256")]


### PR DESCRIPTION
Leading zeros must be stripped from `mpint` values (per [RFC 4251](https://datatracker.ietf.org/doc/html/rfc4251#section-5)), meaning it's possible to see "short" `mpint` values when using them to construct signatures.

These values must be padded with leading zeros before being used in `pXYZ::ecdsa::Signature`, which expect exact-size arrays.

See #290 for details.