### PR TITLE
Add OSC-owned eth address for drips

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,0 +1,7 @@
+{
+  "drips": {
+    "ethereum": {
+      "ownedBy": "0x939121dD13f796C69d0Ac4185787285518081f8D"
+    }
+  }
+}


### PR DESCRIPTION
Add Open Source Collective-owned wallet to collect funds on behalf of rustcrypto/ssh