### PR TITLE
ssh-key v0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "bcrypt-pbkdf",
  "dsa",

--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.7 (2024-10-15)
+### Fixed
+- Parsing `AuthorizedKeys` with whitespace in comments ([#289])
+- `mpint` decoding in ECDSA signatures ([#290], [#291])
+
+[#289]: https://github.com/RustCrypto/SSH/pull/289
+[#290]: https://github.com/RustCrypto/SSH/pull/290
+[#291]: https://github.com/RustCrypto/SSH/pull/291
+
 ## 0.6.6 (2024-04-11)
 ### Added
 - impl `decode_as` for `KeypairData` ([#211])

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.6.6"
+version = "0.6.7"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and


### PR DESCRIPTION
### Fixed
- Parsing `AuthorizedKeys` with whitespace in comments ([#289])
- `mpint` decoding in ECDSA signatures ([#290], [#291])

[#289]: https://github.com/RustCrypto/SSH/pull/289
[#290]: https://github.com/RustCrypto/SSH/pull/290
[#291]: https://github.com/RustCrypto/SSH/pull/291