### PR TITLE
Leverage `core::error::Error`; MSRV 1.81

### DIFF
--- a/.github/workflows/ssh-cipher.yml
+++ b/.github/workflows/ssh-cipher.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ssh-encoding.yml
+++ b/.github/workflows/ssh-encoding.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.73.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.73.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ssh-protocol.yml
+++ b/.github/workflows/ssh-protocol.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.73.0 # MSRV
+          - 1.81.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.80.0
+          toolchain: 1.81.0
           components: clippy
       - run: cargo clippy --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-pre.0"
+version = "0.7.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a560909d2ff20f96fed22d1c8a7c5f732974381d83444ef9c3797e0d1bb716ee"
+checksum = "28e0b1a3c7540d48f58eca5ddfdeb40a44aff3047bf15fe4fb6162a673ddd5fa"
 dependencies = [
  "digest",
  "num-bigint-dig",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
+checksum = "a5a41e5b0754cae5aaf7915f1df1147ba8d316fc6e019cfcc00fbaba96d5e030"
 dependencies = [
  "typenum",
  "zeroize",
@@ -532,18 +532,18 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c1cde4770761bf6bd336f947b9ac1fe700b0a4ec5867cf66cf08597fe89e8c"
+checksum = "c2dfbfa5c6f0906884269722c5478e72fd4d6c0e24fe600332c6d62359567ce1"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "pkcs1"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2f4c73d459a85331915baebd5082dce5ee8ef16fd9a1ca75559ac91e66a9ee"
+checksum = "226eb25e2c46c166ce498ac0f606ac623142d640064879ff445938accddff1e2"
 dependencies = [
  "der",
  "pkcs8",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66180445f1dce533620a7743467ef85fe1c5e80cdaf7c7053609d7a2fbcdae20"
+checksum = "eacd2c7141f32aef1cfd1ad0defb5287a3d94592d7ab57c1ae20e3f9f1f0db1f"
 dependencies = [
  "der",
  "spki",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-pre.2"
+version = "0.10.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e864e43f5d003321ab452feea6450f9611d7be6726489b4ec051da34774c62"
+checksum = "07058e83b684989ab0559f9e22322f4e3f7e49147834ed0bae40486b9e70473c"
 dependencies = [
  "const-oid",
  "digest",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.0"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c98827dc6ed0ea1707286a3d14b4ad4e25e2643169cbf111568a46ff5b09f5"
+checksum = "d1988446eff153796413a73669dfaa4caa3f5ce8b25fac89e3821a39c611772e"
 dependencies = [
  "base16ct",
  "der",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "encryption", "openssh", "ssh"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.81"
 
 [dependencies]
 cipher = "=0.5.0-pre.6"
@@ -38,8 +38,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 hex-literal = "0.4"
 
 [features]
-std = []
-
 aes-cbc = ["dep:aes", "dep:cbc"]
 aes-ctr = ["dep:aes", "dep:ctr"]
 aes-gcm = ["dep:aead", "dep:aes", "dep:aes-gcm"]

--- a/ssh-cipher/README.md
+++ b/ssh-cipher/README.md
@@ -21,7 +21,7 @@ Built on the pure Rust cryptography implementations maintained by the
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -48,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ssh-cipher/badge.svg
 [docs-link]: https://docs.rs/ssh-cipher/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-cipher.yml/badge.svg

--- a/ssh-cipher/src/error.rs
+++ b/ssh-cipher/src/error.rs
@@ -42,5 +42,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/ssh-cipher/src/lib.rs
+++ b/ssh-cipher/src/lib.rs
@@ -21,9 +21,6 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 mod error;
 
 #[cfg(feature = "chacha20poly1305")]

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -13,20 +13,19 @@ categories = ["authentication", "cryptography", "encoding", "no-std", "parser-im
 keywords = ["crypto", "certificate", "key", "openssh", "ssh"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.81"
 
 [dependencies]
 base64ct = { version = "1.4", optional = true }
 bytes = { version = "1", optional = true, default-features = false }
 digest = { version = "=0.11.0-pre.9", optional = true, default-features = false }
-pem-rfc7468 = { version = "1.0.0-rc.1", optional = true }
+pem-rfc7468 = { version = "1.0.0-rc.2", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4.1"
 
 [features]
 alloc = ["base64ct?/alloc", "pem-rfc7468?/alloc"]
-std = ["alloc", "base64ct?/std", "digest?/std", "pem-rfc7468?/std"]
 
 base64 = ["dep:base64ct"]
 bytes = ["alloc", "dep:bytes"]

--- a/ssh-encoding/README.md
+++ b/ssh-encoding/README.md
@@ -16,7 +16,7 @@ in [RFC4251].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.71** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ssh-encoding/badge.svg
 [docs-link]: https://docs.rs/ssh-encoding/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-encoding.yml/badge.svg

--- a/ssh-encoding/src/error.rs
+++ b/ssh-encoding/src/error.rs
@@ -37,6 +37,19 @@ pub enum Error {
     },
 }
 
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            // TODO(tarcieri): re-add support when `base64ct` uses `core::error`
+            //#[cfg(feature = "base64")]
+            //Self::Base64(err) => Some(err),
+            #[cfg(feature = "pem")]
+            Self::Pem(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -99,18 +112,5 @@ impl From<base64ct::InvalidLengthError> for Error {
 impl From<pem_rfc7468::Error> for Error {
     fn from(err: pem_rfc7468::Error) -> Error {
         Error::Pem(err)
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            #[cfg(feature = "base64")]
-            Self::Base64(err) => Some(err),
-            #[cfg(feature = "pem")]
-            Self::Pem(err) => Some(err),
-            _ => None,
-        }
     }
 }

--- a/ssh-encoding/src/label.rs
+++ b/ssh-encoding/src/label.rs
@@ -66,6 +66,8 @@ impl LabelError {
     }
 }
 
+impl core::error::Error for LabelError {}
+
 impl fmt::Display for LabelError {
     #[cfg(not(feature = "alloc"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -77,6 +79,3 @@ impl fmt::Display for LabelError {
         write!(f, "invalid label: '{}'", self.label)
     }
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for LabelError {}

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -24,8 +24,6 @@
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 mod checked;
 mod decode;

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["authentication", "cryptography", "encoding", "no-std", "parser-im
 keywords = ["crypto", "certificate", "openssh", "ssh", "sshsig"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.81"
 
 [dependencies]
 cipher = { package = "ssh-cipher", version = "=0.3.0-pre.2", features = ["zeroize"], path = "../ssh-cipher" }
@@ -28,15 +28,15 @@ zeroize = { version = "1", default-features = false }
 # optional dependencies
 bcrypt-pbkdf = { version = "=0.11.0-pre.1", optional = true, default-features = false, features = ["alloc"] }
 bigint = { package = "num-bigint-dig", version = "0.8", optional = true, default-features = false }
-dsa = { version = "=0.7.0-pre.0", optional = true, default-features = false }
+dsa = { version = "=0.7.0-pre.1", optional = true, default-features = false }
 ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
 home = { version = "0.5", optional = true }
 p256 = { version = "=0.14.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "=0.14.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
 p521 = { version = "=0.14.0-pre.1", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.6.4", optional = true, default-features = false }
-rsa = { version = "=0.10.0-pre.2", optional = true, default-features = false, features = ["sha2"] }
-sec1 = { version = "0.8.0-rc.0", optional = true, default-features = false, features = ["point"] }
+rsa = { version = "=0.10.0-pre.3", optional = true, default-features = false, features = ["sha2"] }
+sec1 = { version = "0.8.0-rc.3", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1", optional = true }
 sha1 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 
@@ -53,7 +53,6 @@ alloc = [
 ]
 std = [
     "alloc",
-    "encoding/std",
     "p256?/std",
     "p384?/std",
     "p521?/std",

--- a/ssh-key/README.md
+++ b/ssh-key/README.md
@@ -86,7 +86,7 @@ functionality for a particular SSH key algorithm.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.73** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -113,7 +113,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ssh-key/badge.svg
 [docs-link]: https://docs.rs/ssh-key/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.73+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-key.yml/badge.svg

--- a/ssh-protocol/Cargo.toml
+++ b/ssh-protocol/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["authentication", "cryptography", "encoding", "no-std"]
 keywords = ["crypto", "certificate", "openssh", "ssh", "sshsig"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.81"
 
 [dependencies]
 cipher = { package = "ssh-cipher", version = "=0.3.0-pre.2", default-features = false, path = "../ssh-cipher" }
@@ -23,7 +23,7 @@ key = { package = "ssh-key", version = "=0.7.0-pre.1", default-features = false,
 [features]
 default = ["std"]
 alloc = ["encoding/alloc", "key/alloc"]
-std = ["alloc", "encoding/std", "key/std"]
+std = ["alloc", "key/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ssh-protocol/README.md
+++ b/ssh-protocol/README.md
@@ -16,7 +16,7 @@ OpenSSH-specific extensions (WIP).
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.73** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -43,7 +43,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ssh-protocol/badge.svg
 [docs-link]: https://docs.rs/ssh-protocol/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.73+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/346919-SSH
 [build-image]: https://github.com/RustCrypto/SSH/actions/workflows/ssh-protocol.yml/badge.svg


### PR DESCRIPTION
Now that `core::error::Error` is stable in 1.81, leverages it to make the `Error` impl always available.

Since `ssh-cipher` has no other dependencies on `std`, removes the `std` feature from this crate entirely.