### PR TITLE
ssh-key: add CHANGELOG.md entries vor v0.6.6+v0.6.7

### DIFF
--- a/ssh-key/CHANGELOG.md
+++ b/ssh-key/CHANGELOG.md
@@ -20,6 +20,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#210]: https://github.com/RustCrypto/SSH/pull/210
 [#211]: https://github.com/RustCrypto/SSH/pull/211
 
+## 0.6.7 (2024-10-15)
+### Fixed
+- Parsing `AuthorizedKeys` with whitespace in comments ([#289])
+- `mpint` decoding in ECDSA signatures ([#290], [#291])
+
+[#289]: https://github.com/RustCrypto/SSH/pull/289
+[#290]: https://github.com/RustCrypto/SSH/pull/290
+[#291]: https://github.com/RustCrypto/SSH/pull/291
+
+## 0.6.6 (2024-04-11)
+### Added
+- impl `decode_as` for `KeypairData` ([#211])
+
+### Changed
+- clarify SSH vs OpenSSH formats ([#206])
+
+### Fixed
+- fix `certificate::OptionsMap` encoding ([#207])
+- fixup `EcdsaPrivateKey` Debug impl ([#210])
+
+[#206]: https://github.com/RustCrypto/SSH/pull/206
+[#207]: https://github.com/RustCrypto/SSH/pull/207
+[#210]: https://github.com/RustCrypto/SSH/pull/210
+[#211]: https://github.com/RustCrypto/SSH/pull/211
+
 ## 0.6.5 (2024-03-12)
 ### Added
 - `Sk*` constructors ([#201], [#204])


### PR DESCRIPTION
These releases were performed on the `stable` branch. See #302.