### PR TITLE
Allow padding up to MAX_BLOCK_SIZE

### DIFF
--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -575,7 +575,7 @@ impl PrivateKey {
 
         let padding_len = reader.remaining_len();
 
-        if padding_len >= block_size {
+        if padding_len >= MAX_BLOCK_SIZE {
             return Err(encoding::Error::Length.into());
         }
 


### PR DESCRIPTION
Hi,

I have a problem using `russh` with my `ed25519` ssh key.

There is a check on the padding length which seems wrong, the padding is correctly formatted its just longer than the cipher block length, im not sure why its longer than 8 bytes, but it seems fair to allow padding's up to `MAX_BLOCK_SIZE` as long as they are valid.

The key was generated some time ago using `ssh-keygen` 
![Screenshot from 2024-11-29 13-30-01](https://github.com/user-attachments/assets/ce6ca5e3-47b8-4771-8997-73ef1e88ebd5)

