### PR TITLE
ssh-key: support making RSA-SHA1 signatures

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -680,9 +680,7 @@ impl Signer<Signature> for (&RsaKeypair, Option<HashAlg>) {
         .map_err(|_| signature::Error::new())?;
 
         Ok(Signature {
-            algorithm: Algorithm::Rsa {
-                hash: self.1,
-            },
+            algorithm: Algorithm::Rsa { hash: self.1 },
             data: data.to_vec(),
         })
     }

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -681,7 +681,7 @@ impl Signer<Signature> for (&RsaKeypair, Option<HashAlg>) {
 
         Ok(Signature {
             algorithm: Algorithm::Rsa {
-                hash: Some(HashAlg::Sha512),
+                hash: self.1,
             },
             data: data.to_vec(),
         })

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -672,9 +672,9 @@ impl Signer<Signature> for (&RsaKeypair, Option<HashAlg>) {
             Some(HashAlg::Sha256) => {
                 rsa::pkcs1v15::SigningKey::<Sha256>::try_from(self.0)?.try_sign(message)
             }
-            #[cfg(feature = "rsa-sha1")]
+            #[cfg(all(feature = "rsa", feature = "sha1"))]
             None => rsa::pkcs1v15::SigningKey::<Sha1>::try_from(self.0)?.try_sign(message),
-            #[cfg(not(feature = "rsa-sha1"))]
+            #[cfg(not(all(feature = "rsa", feature = "sha1")))]
             None => return Err(Algorithm::Rsa { hash: None }.unsupported_error().into()),
         }
         .map_err(|_| signature::Error::new())?;

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -663,11 +663,21 @@ impl Verifier<Signature> for EcdsaPublicKey {
 }
 
 #[cfg(feature = "rsa")]
-impl Signer<Signature> for RsaKeypair {
+impl Signer<Signature> for (&RsaKeypair, Option<HashAlg>) {
     fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
-        let data = rsa::pkcs1v15::SigningKey::<Sha512>::try_from(self)?
-            .try_sign(message)
-            .map_err(|_| signature::Error::new())?;
+        let data = match self.1 {
+            Some(HashAlg::Sha512) => {
+                rsa::pkcs1v15::SigningKey::<Sha512>::try_from(self.0)?.try_sign(message)
+            }
+            Some(HashAlg::Sha256) => {
+                rsa::pkcs1v15::SigningKey::<Sha256>::try_from(self.0)?.try_sign(message)
+            }
+            #[cfg(feature = "rsa-sha1")]
+            None => rsa::pkcs1v15::SigningKey::<Sha1>::try_from(self.0)?.try_sign(message),
+            #[cfg(not(feature = "rsa-sha1"))]
+            None => return Err(Algorithm::Rsa { hash: None }.unsupported_error().into()),
+        }
+        .map_err(|_| signature::Error::new())?;
 
         Ok(Signature {
             algorithm: Algorithm::Rsa {
@@ -675,6 +685,13 @@ impl Signer<Signature> for RsaKeypair {
             },
             data: data.to_vec(),
         })
+    }
+}
+
+#[cfg(feature = "rsa")]
+impl Signer<Signature> for RsaKeypair {
+    fn try_sign(&self, message: &[u8]) -> signature::Result<Signature> {
+        (self, Some(HashAlg::Sha512)).try_sign(message)
     }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
>  This PR is branched from #315 and depends on it 

fixes #322

This PR implements `Signer` for `(&RsaKeypair, Option<HashAlg>)`. I'm not happy about the API, but I wanted to avoid creating a new trait just for this. Open to suggestions.