### PR TITLE
ssh-key: fix documentation typo

### DIFF
--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -131,7 +131,7 @@ impl Signature {
 
     /// Placeholder signature used by the certificate builder.
     ///
-    /// This is guaranteed generate an error if anything attempts to encode it.
+    /// This is guaranteed to generate an error if anything attempts to encode it.
     pub(crate) fn placeholder() -> Self {
         Self {
             algorithm: Algorithm::default(),


### PR DESCRIPTION
This is just a simple documentation fix.