### PR TITLE
ssh-encoding: remove length prefix from `[u8; N]` encoding

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -116,16 +116,17 @@ impl Decode for usize {
 /// > data is sometimes represented as an array of bytes, written
 /// > `byte[n]`, where n is the number of bytes in the array.
 ///
+/// Note that unlike `string`, this type is encoded without a length prefix,
+/// but instead implicitly obtains its length as `N`.
+///
 /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 impl<const N: usize> Decode for [u8; N] {
     type Error = Error;
 
     fn decode(reader: &mut impl Reader) -> Result<Self> {
-        reader.read_prefixed(|reader| {
-            let mut result = [(); N].map(|_| 0);
-            reader.read(&mut result)?;
-            Ok(result)
-        })
+        let mut result = [0u8; N];
+        reader.read(&mut result)?;
+        Ok(result)
     }
 }
 

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -158,6 +158,9 @@ impl Encode for [u8] {
 /// > data is sometimes represented as an array of bytes, written
 /// > `byte[n]`, where n is the number of bytes in the array.
 ///
+/// Note that unlike `string`, this type is encoded without a length prefix,
+/// but instead implicitly obtains its length as `N`.
+///
 /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 impl<const N: usize> Encode for [u8; N] {
     fn encoded_len(&self) -> Result<usize, Error> {
@@ -165,7 +168,7 @@ impl<const N: usize> Encode for [u8; N] {
     }
 
     fn encode(&self, writer: &mut impl Writer) -> Result<(), Error> {
-        self.as_slice().encode(writer)
+        writer.write(self)
     }
 }
 

--- a/ssh-encoding/tests/decode.rs
+++ b/ssh-encoding/tests/decode.rs
@@ -52,8 +52,8 @@ fn reject_oversize_usize() {
 }
 
 #[test]
-fn decode_byte_slice() {
-    let mut bytes = hex!("000000076578616d706c65").as_slice();
+fn decode_byte_array() {
+    let mut bytes = hex!("6578616d706c65").as_slice();
     let ret = <[u8; 7]>::decode(&mut bytes).unwrap();
     assert_eq!(&ret, b"example");
 }

--- a/ssh-encoding/tests/encode.rs
+++ b/ssh-encoding/tests/encode.rs
@@ -41,9 +41,16 @@ fn encode_usize() {
 }
 
 #[test]
-fn encode_byte_slice() {
+fn encode_byte_array() {
     let mut out = Vec::new();
     b"example".encode(&mut out).unwrap();
+    assert_eq!(out, hex!("6578616d706c65"));
+}
+
+#[test]
+fn encode_byte_slice() {
+    let mut out = Vec::new();
+    b"example".as_slice().encode(&mut out).unwrap();
     assert_eq!(out, hex!("000000076578616d706c65"));
 }
 

--- a/ssh-key/src/public/ed25519.rs
+++ b/ssh-key/src/public/ed25519.rs
@@ -7,7 +7,18 @@ use core::fmt;
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 
 /// Ed25519 public key.
-// TODO(tarcieri): use `ed25519::PublicKey`? (doesn't exist yet)
+///
+/// Encodings for Ed25519 public keys are described in [RFC8709 § 4]:
+///
+/// > The "ssh-ed25519" key format has the following encoding:
+/// >
+/// > **string** "ssh-ed25519"
+/// >
+/// > **string** key
+/// >
+/// > Here, 'key' is the 32-octet public key described in RFC8032
+///
+/// [RFC8709 § 4]: https://datatracker.ietf.org/doc/html/rfc8709#section-4
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Ed25519PublicKey(pub [u8; Self::BYTE_SIZE]);
 
@@ -38,7 +49,7 @@ impl Encode for Ed25519PublicKey {
     }
 
     fn encode(&self, writer: &mut impl Writer) -> encoding::Result<()> {
-        self.0.encode(writer)?;
+        self.0.as_slice().encode(writer)?;
         Ok(())
     }
 }


### PR DESCRIPTION
The type `[u8; N]` maps naturally to SSH's `byte[n]` type, which has no length prefix because `n` is known a priori.

In cases where `[u8; N]` is being used to store an SSH `string`, such as Ed25519 public keys, it first needs to be converted to `[u8]` (which maps to `string`) using `as_slice()`