### PR TITLE
ssh-encoding: fix `string` comments on encoding trait impls

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -179,11 +179,14 @@ impl Decode for Vec<String> {
     }
 }
 
-/// Decodes `Bytes` from `byte[n]` as described in [RFC4251 § 5]:
+/// Decodes `Bytes` from `string` as described in [RFC4251 § 5]:
 ///
-/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
-/// > data is sometimes represented as an array of bytes, written
-/// > `byte[n]`, where n is the number of bytes in the array.
+/// > Arbitrary length binary string.  Strings are allowed to contain
+/// > arbitrary binary data, including null characters and 8-bit
+/// > characters.  They are stored as a uint32 containing its length
+/// > (number of bytes that follow) and zero (= empty string) or more
+/// > bytes that are the value of the string.  Terminating null
+/// > characters are not used.
 ///
 /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 #[cfg(feature = "bytes")]

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -134,11 +134,14 @@ impl Encode for usize {
     }
 }
 
-/// Encodes `[u8]` into `byte[n]` as described in [RFC4251 § 5]:
+/// Encodes `[u8]` into `string` as described in [RFC4251 § 5]:
 ///
-/// > A byte represents an arbitrary 8-bit value (octet).  Fixed length
-/// > data is sometimes represented as an array of bytes, written
-/// > `byte[n]`, where n is the number of bytes in the array.
+/// > Arbitrary length binary string.  Strings are allowed to contain
+/// > arbitrary binary data, including null characters and 8-bit
+/// > characters.  They are stored as a uint32 containing its length
+/// > (number of bytes that follow) and zero (= empty string) or more
+/// > bytes that are the value of the string.  Terminating null
+/// > characters are not used.
 ///
 /// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 impl Encode for [u8] {


### PR DESCRIPTION
The impls of `Decode` for `Bytes` and `Encode` for `[u8]` made reference to `byte[n]`, i.e. a fixed length bytestring, however both these types are analogues for `string`, which is encoded with a length prefix.

The comments have been updated to reflect the correct type they map to in the SSH encoding schema, which is `string`.