### PR TITLE
ssh-derive: fix derive macros for `Encode` and `Decode`

### DIFF
--- a/ssh-derive/src/decode.rs
+++ b/ssh-derive/src/decode.rs
@@ -49,12 +49,13 @@ impl DeriveDecode {
         let body = lowerer.into_tokens();
 
         quote! {
+            #[automatically_derived]
             impl #generics ::ssh_encoding::Decode for #ident #generics #where_clause {
                 type Error = ::ssh_encoding::Error;
 
-                fn decode(reader: &mut impl Reader) -> Result<Self, Self::Error> {
+                fn decode(reader: &mut impl ::ssh_encoding::Reader) -> Result<Self, Self::Error> {
                     Ok(Self {
-                        #(#body)*,
+                        #(#body),*
                     })
                 }
             }
@@ -80,8 +81,8 @@ impl FieldLowerer {
     fn add_field(&mut self, field: &FieldIr) {
         let ident = field.ident.clone();
         let ty = field.ty.clone();
-        let field = quote! { #ident: #ty::decode()? };
-        self.body.push(field)
+        let field = quote! { #ident: <#ty as ::ssh_encoding::Decode>::decode(reader)? };
+        self.body.push(field);
     }
 
     /// Return the resulting tokens.


### PR DESCRIPTION
The previous code would panic for structs with more than one field, and was dependent on certain traits being visible. This should now be fixed. I find testing derive macros a bit painful. Instead some doctests in the consuming crate `ssh-encoding` could serve as implicit integration tests. I'll add a PR for that if/when this one is resolved.

I haven't done anything in terms of configuration, so this only fixes the functionality that was intended already. I.e. the `ssh` macro attribute is still unused.