### PR TITLE
ssh-encoding: improve rustdoc

### DIFF
--- a/ssh-encoding/src/decode.rs
+++ b/ssh-encoding/src/decode.rs
@@ -12,7 +12,7 @@ use alloc::{string::String, vec::Vec};
 use bytes::Bytes;
 
 /// Maximum size of a `usize` this library will accept.
-const MAX_SIZE: usize = 0xFFFFF;
+const MAX_USIZE: usize = 0xFFFFF;
 
 /// Decoding trait.
 ///
@@ -102,7 +102,7 @@ impl Decode for usize {
     fn decode(reader: &mut impl Reader) -> Result<Self> {
         let n = usize::try_from(u32::decode(reader)?)?;
 
-        if n <= MAX_SIZE {
+        if n <= MAX_USIZE {
             Ok(n)
         } else {
             Err(Error::Overflow)
@@ -162,6 +162,24 @@ impl Decode for String {
     }
 }
 
+/// Decodes `Vec<String>` from `name-list` as described in [RFC4251 § 5]:
+///
+/// > A string containing a comma-separated list of names.  A name-list
+/// > is represented as a uint32 containing its length (number of bytes
+/// > that follow) followed by a comma-separated list of zero or more
+/// > names.  A name MUST have a non-zero length, and it MUST NOT
+/// > contain a comma (",").  As this is a list of names, all of the
+/// > elements contained are names and MUST be in US-ASCII.  Context may
+/// > impose additional restrictions on the names.  For example, the
+/// > names in a name-list may have to be a list of valid algorithm
+/// > identifiers (see Section 6 below), or a list of [RFC3066] language
+/// > tags.  The order of the names in a name-list may or may not be
+/// > significant.  Again, this depends on the context in which the list
+/// > is used.  Terminating null characters MUST NOT be used, neither
+/// > for the individual names, nor for the list as a whole.
+///
+/// [RFC3066]: https://datatracker.ietf.org/doc/html/rfc3066
+/// [RFC4251 § 5]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
 #[cfg(feature = "alloc")]
 impl Decode for Vec<String> {
     type Error = Error;


### PR DESCRIPTION
For the listing of RFC4251 types, uses better headings for each type, and adds a list of types which have compatible `Decode`/`Encode` impls