### PR TITLE
Move `Mpint` from `ssh-key` to `ssh-encoding`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,8 +860,11 @@ dependencies = [
  "bytes",
  "digest",
  "hex-literal",
+ "num-bigint-dig",
  "pem-rfc7468",
  "ssh-derive",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -21,14 +21,20 @@ bytes = { version = "1", optional = true, default-features = false }
 digest = { version = "=0.11.0-pre.9", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.2", optional = true }
 ssh-derive = { version = "0.0.1-alpha", optional = true, path = "../ssh-derive" }
+subtle = { version = "2", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
+
+# TODO(tarcieri): migrate to `crypto-bigint`
+bigint = { package = "num-bigint-dig", version = "0.8", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "1"
 
 [features]
-alloc = ["base64ct?/alloc", "pem-rfc7468?/alloc"]
+alloc = ["base64ct?/alloc", "pem-rfc7468?/alloc", "zeroize?/alloc"]
 
 base64 = ["dep:base64ct"]
+bigint = ["alloc", "zeroize", "dep:bigint"]
 bytes = ["alloc", "dep:bytes"]
 pem = ["base64", "dep:pem-rfc7468"]
 derive = ["ssh-derive"]

--- a/ssh-encoding/src/error.rs
+++ b/ssh-encoding/src/error.rs
@@ -23,6 +23,10 @@ pub enum Error {
     /// Invalid length.
     Length,
 
+    /// `mpint` encoding errors.
+    #[cfg(feature = "alloc")]
+    MpintEncoding,
+
     /// Overflow errors.
     Overflow,
 
@@ -60,6 +64,8 @@ impl fmt::Display for Error {
             Error::CharacterEncoding => write!(f, "character encoding invalid"),
             Error::Label(err) => write!(f, "{}", err),
             Error::Length => write!(f, "length invalid"),
+            #[cfg(feature = "alloc")]
+            Error::MpintEncoding => write!(f, "`mpint` encoding invalid"),
             Error::Overflow => write!(f, "internal overflow error"),
             #[cfg(feature = "pem")]
             Error::Pem(err) => write!(f, "{err}"),

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -83,6 +83,7 @@
 //! The UTF-8 mapping does not alter the encoding of US-ASCII characters.
 //!
 //! ### `mpint`: multiple precision integers in two's complement format
+//! #### [`Decode`]/[`Encode`] trait impls: `Mpint`
 //!
 //! Stored as a byte string, 8 bits per byte, MSB first (a.k.a. big endian).
 //!
@@ -214,6 +215,8 @@ mod decode;
 mod encode;
 mod error;
 mod label;
+#[cfg(feature = "alloc")]
+mod mpint;
 #[macro_use]
 mod reader;
 mod writer;
@@ -232,6 +235,9 @@ pub use crate::{
     reader::Reader,
     writer::Writer,
 };
+
+#[cfg(feature = "alloc")]
+pub use crate::mpint::Mpint;
 
 #[cfg(feature = "base64")]
 pub use crate::{base64::Base64Reader, base64::Base64Writer};

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 
 [dependencies]
 cipher = { package = "ssh-cipher", version = "=0.3.0-pre.2", features = ["zeroize"], path = "../ssh-cipher" }
-encoding = { package = "ssh-encoding", version = "=0.3.0-pre.1", features = ["base64", "digest", "pem"], path = "../ssh-encoding" }
+encoding = { package = "ssh-encoding", version = "=0.3.0-pre.1", features = ["base64", "digest", "pem", "subtle", "zeroize"], path = "../ssh-encoding" }
 sha2 = { version = "=0.11.0-pre.4", default-features = false }
 signature = { version = "=2.3.0-pre.4", default-features = false }
 subtle = { version = "2", default-features = false }
@@ -66,7 +66,7 @@ std = [
 ]
 
 crypto = ["ed25519", "p256", "p384", "p521", "rsa"] # NOTE: `dsa` is obsolete/weak
-dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "signature/rand_core"]
+dsa = ["dep:bigint", "dep:dsa", "dep:sha1", "alloc", "encoding/bigint", "signature/rand_core"]
 ecdsa = ["dep:sec1"]
 ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [
@@ -83,7 +83,7 @@ p256 = ["dep:p256", "ecdsa"]
 p384 = ["dep:p384", "ecdsa"]
 p521 = ["dep:p521", "ecdsa"]
 ppk = ["dep:hex", "alloc", "cipher/aes-cbc", "dep:hmac", "dep:argon2", "dep:sha1"]
-rsa = ["dep:bigint", "dep:rsa", "alloc", "rand_core"]
+rsa = ["dep:bigint", "dep:rsa", "alloc", "encoding/bigint", "rand_core"]
 sha1 = ["dep:sha1"]
 tdes = ["cipher/tdes", "encryption"]
 

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -158,8 +158,6 @@ mod kdf;
 
 #[cfg(feature = "std")]
 mod dot_ssh;
-#[cfg(feature = "alloc")]
-mod mpint;
 #[cfg(feature = "ppk")]
 mod ppk;
 #[cfg(feature = "alloc")]
@@ -181,13 +179,15 @@ pub use encoding::pem::LineEnding;
 pub use sha2;
 
 #[cfg(feature = "alloc")]
-pub use crate::{
-    algorithm::AlgorithmName,
-    certificate::Certificate,
-    known_hosts::KnownHosts,
-    mpint::Mpint,
-    signature::{Signature, SigningKey},
-    sshsig::SshSig,
+pub use {
+    crate::{
+        algorithm::AlgorithmName,
+        certificate::Certificate,
+        known_hosts::KnownHosts,
+        signature::{Signature, SigningKey},
+        sshsig::SshSig,
+    },
+    encoding::Mpint,
 };
 
 #[cfg(feature = "ecdsa")]

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -97,7 +97,7 @@ impl TryFrom<DsaPrivateKey> for dsa::BigUint {
     type Error = Error;
 
     fn try_from(key: DsaPrivateKey) -> Result<dsa::BigUint> {
-        dsa::BigUint::try_from(&key.inner)
+        Ok(dsa::BigUint::try_from(&key.inner)?)
     }
 }
 
@@ -106,7 +106,7 @@ impl TryFrom<&DsaPrivateKey> for dsa::BigUint {
     type Error = Error;
 
     fn try_from(key: &DsaPrivateKey) -> Result<dsa::BigUint> {
-        dsa::BigUint::try_from(&key.inner)
+        Ok(dsa::BigUint::try_from(&key.inner)?)
     }
 }
 


### PR DESCRIPTION
This makes it possible to support the `mpint` data type encoding in other applications than just `ssh-key`.