### PR TITLE
ssh-key: extract a `Comment` type

### DIFF
--- a/ssh-key/src/comment.rs
+++ b/ssh-key/src/comment.rs
@@ -1,0 +1,158 @@
+//! SSH key comment support.
+
+use alloc::{borrow::ToOwned, boxed::Box, string::String, vec::Vec};
+use core::{
+    convert::Infallible,
+    fmt,
+    str::{self, FromStr},
+};
+use encoding::{Decode, Encode, Error, Reader, Writer};
+
+/// SSH key comment (e.g. email address of owner)
+///
+/// Comments may be found in both the binary serialization of  [`PrivateKey`] as well as the text
+/// serialization of [`PublicKey`].
+///
+/// The binary serialization of [`PrivateKey`] stores the comment encoded as an [RFC4251]
+/// `string` type which can contain arbitrary binary data and does not necessarily represent valid
+/// UTF-8. To support round trip encoding of such comments.
+///
+/// To support round-trip encoding of such comments, this type also supports arbitrary binary data.
+///
+/// [RFC4251]: https://datatracker.ietf.org/doc/html/rfc4251#section-5
+/// [`PrivateKey`]: crate::PrivateKey
+/// [`PublicKey`]: crate::PublicKey
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Comment(Box<[u8]>);
+
+impl AsRef<[u8]> for Comment {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsRef<str> for Comment {
+    fn as_ref(&self) -> &str {
+        self.as_str_lossy()
+    }
+}
+
+impl Decode for Comment {
+    type Error = Error;
+
+    fn decode(reader: &mut impl Reader) -> encoding::Result<Self> {
+        Vec::<u8>::decode(reader).map(Into::into)
+    }
+}
+
+impl Encode for Comment {
+    fn encoded_len(&self) -> Result<usize, Error> {
+        self.0.encoded_len()
+    }
+
+    fn encode(&self, writer: &mut impl Writer) -> Result<(), Error> {
+        self.0.encode(writer)
+    }
+}
+
+impl FromStr for Comment {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Comment, Infallible> {
+        Ok(s.into())
+    }
+}
+
+impl From<&str> for Comment {
+    fn from(s: &str) -> Comment {
+        s.to_owned().into()
+    }
+}
+
+impl From<String> for Comment {
+    fn from(s: String) -> Self {
+        s.into_bytes().into()
+    }
+}
+
+impl From<&[u8]> for Comment {
+    fn from(bytes: &[u8]) -> Comment {
+        bytes.to_owned().into()
+    }
+}
+
+impl From<Vec<u8>> for Comment {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(vec.into_boxed_slice())
+    }
+}
+
+impl From<Comment> for Vec<u8> {
+    fn from(comment: Comment) -> Vec<u8> {
+        comment.0.into()
+    }
+}
+
+impl TryFrom<Comment> for String {
+    type Error = Error;
+
+    fn try_from(comment: Comment) -> Result<String, Error> {
+        comment.as_str().map(ToOwned::to_owned)
+    }
+}
+
+impl fmt::Display for Comment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str_lossy())
+    }
+}
+
+impl Comment {
+    /// Interpret the comment as raw binary data.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Interpret the comment as a UTF-8 string.
+    pub fn as_str(&self) -> Result<&str, Error> {
+        Ok(str::from_utf8(&self.0)?)
+    }
+
+    /// Interpret the comment as a UTF-8 string.
+    ///
+    /// This is the maximal prefix of the comment which can be interpreted as valid UTF-8.
+    // TODO(tarcieri): precompute and store the offset which represents this prefix?
+    #[cfg(feature = "alloc")]
+    pub fn as_str_lossy(&self) -> &str {
+        for i in (1..=self.len()).rev() {
+            if let Ok(s) = str::from_utf8(&self.0[..i]) {
+                return s;
+            }
+        }
+
+        ""
+    }
+
+    /// Is the comment empty?
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Get the length of this comment in bytes.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Comment;
+
+    #[test]
+    fn as_str_lossy_ignores_non_utf8_data() {
+        const EXAMPLE: &[u8] = b"hello world\xc3\x28";
+
+        let comment = Comment::from(EXAMPLE);
+        assert_eq!(comment.as_str_lossy(), "hello world");
+    }
+}

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! // Key attributes
 //! assert_eq!(public_key.algorithm(), ssh_key::Algorithm::Ed25519);
-//! assert_eq!(public_key.comment(), "user@example.com");
+//! assert_eq!(public_key.comment().as_bytes(), b"user@example.com");
 //!
 //! // Key data: in this example an Ed25519 key
 //! if let Some(ed25519_public_key) = public_key.key_data().ed25519() {
@@ -100,7 +100,7 @@
 //!
 //! // Key attributes
 //! assert_eq!(private_key.algorithm(), ssh_key::Algorithm::Ed25519);
-//! assert_eq!(private_key.comment(), "user@example.com");
+//! assert_eq!(private_key.comment().as_bytes(), b"user@example.com");
 //!
 //! // Key data: in this example an Ed25519 key
 //! if let Some(ed25519_keypair) = private_key.key_data().ed25519() {
@@ -156,6 +156,8 @@ mod error;
 mod fingerprint;
 mod kdf;
 
+#[cfg(feature = "alloc")]
+mod comment;
 #[cfg(feature = "std")]
 mod dot_ssh;
 #[cfg(feature = "ppk")]
@@ -183,6 +185,7 @@ pub use {
     crate::{
         algorithm::AlgorithmName,
         certificate::Certificate,
+        comment::Comment,
         known_hosts::KnownHosts,
         signature::{Signature, SigningKey},
         sshsig::SshSig,

--- a/ssh-key/tests/authorized_keys.rs
+++ b/ssh-key/tests/authorized_keys.rs
@@ -15,7 +15,7 @@ fn read_example_file() {
         authorized_keys[0].public_key().to_string(),
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti"
     );
-    assert_eq!(authorized_keys[0].public_key().comment_bytes(), b"");
+    assert_eq!(authorized_keys[0].public_key().comment().as_bytes(), b"");
 
     assert_eq!(
         authorized_keys[1].config_opts().to_string(),
@@ -26,7 +26,7 @@ fn read_example_file() {
         "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= user2@example.com"
     );
     assert_eq!(
-        authorized_keys[1].public_key().comment_bytes(),
+        authorized_keys[1].public_key().comment().as_bytes(),
         b"user2@example.com"
     );
 
@@ -39,7 +39,7 @@ fn read_example_file() {
         "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA== user3@example.com"
     );
     assert_eq!(
-        authorized_keys[2].public_key().comment_bytes(),
+        authorized_keys[2].public_key().comment().as_bytes(),
         b"user3@example.com"
     );
 
@@ -52,7 +52,7 @@ fn read_example_file() {
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== user4@example.com"
     );
     assert_eq!(
-        authorized_keys[3].public_key().comment_bytes(),
+        authorized_keys[3].public_key().comment().as_bytes(),
         b"user4@example.com"
     );
 
@@ -61,7 +61,7 @@ fn read_example_file() {
         "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBN76zuqnjypL54/w4763l7q1Sn3IBYHptJ5wcYfEWkzeNTvpexr05Z18m2yPT2SWRd1JJ8Aj5TYidG9MdSS5J78= hello world this is a long comment"
     );
     assert_eq!(
-        authorized_keys[4].public_key().comment_bytes(),
+        authorized_keys[4].public_key().comment().as_bytes(),
         b"hello world this is a long comment"
     );
 }

--- a/ssh-key/tests/known_hosts.rs
+++ b/ssh-key/tests/known_hosts.rs
@@ -19,7 +19,7 @@ fn read_example_file() {
         known_hosts[0].public_key().to_string(),
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILM+rvN+ot98qgEN796jTiQfZfG1KaT0PtFDJ/XFSqti"
     );
-    assert_eq!(known_hosts[0].public_key().comment_bytes(), b"");
+    assert_eq!(known_hosts[0].public_key().comment().as_bytes(), b"");
 
     assert_eq!(known_hosts[1].marker(), None);
     assert_eq!(
@@ -34,7 +34,10 @@ fn read_example_file() {
         known_hosts[1].public_key().to_string(),
         "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHwf2HMM5TRXvo2SQJjsNkiDD5KqiiNjrGVv3UUh+mMT5RHxiRtOnlqvjhQtBq0VpmpCV/PwUdhOig4vkbqAcEc= example.com"
     );
-    assert_eq!(known_hosts[1].public_key().comment_bytes(), b"example.com");
+    assert_eq!(
+        known_hosts[1].public_key().comment().as_bytes(),
+        b"example.com"
+    );
 
     assert_eq!(known_hosts[2].marker(), Some(&Marker::Revoked));
     assert_eq!(
@@ -54,7 +57,7 @@ fn read_example_file() {
         known_hosts[2].public_key().to_string(),
         "ssh-dss AAAAB3NzaC1kc3MAAACBANw9iSUO2UYhFMssjUgW46URqv8bBrDgHeF8HLBOWBvKuXF2Rx2J/XyhgX48SOLMuv0hcPaejlyLarabnF9F2V4dkpPpZSJ+7luHmxEjNxwhsdtg8UteXAWkeCzrQ6MvRJZHcDBjYh56KGvslbFnJsGLXlI4PQCyl6awNImwYGilAAAAFQCJGBU3hZf+QtP9Jh/nbfNlhFu7hwAAAIBHObOQioQVRm3HsVb7mOy3FVKhcLoLO3qoG9gTkd4KeuehtFAC3+rckiX7xSCnE/5BBKdL7VP9WRXac2Nlr9Pwl3e7zPut96wrCHt/TZX6vkfXKkbpUIj5zSqfvyNrWKaYJkfzwAQwrXNS1Hol676Ud/DDEn2oatdEhkS3beWHXAAAAIBgQqaz/YYTRMshzMzYcZ4lqgvgmA55y6v0h39e8HH2A5dwNS6sPUw2jyna+le0dceNRJifFld1J+WYM0vmquSr11DDavgEidOSaXwfMvPPPJqLmbzdtT16N+Gij9U9STQTHPQcQ3xnNNHgQAStzZJbhLOVbDDDo5BO7LMUALDfSA=="
     );
-    assert_eq!(known_hosts[2].public_key().comment_bytes(), b"");
+    assert_eq!(known_hosts[2].public_key().comment().as_bytes(), b"");
 
     assert_eq!(known_hosts[3].marker(), Some(&Marker::CertAuthority));
     assert_eq!(
@@ -66,7 +69,7 @@ fn read_example_file() {
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC0WRHtxuxefSJhpIxGq4ibGFgwYnESPm8C3JFM88A1JJLoprenklrd7VJ+VH3Ov/bQwZwLyRU5dRmfR/SWTtIPWs7tToJVayKKDB+/qoXmM5ui/0CU2U4rCdQ6PdaCJdC7yFgpPL8WexjWN06+eSIKYz1AAXbx9rRv1iasslK/KUqtsqzVliagI6jl7FPO2GhRZMcso6LsZGgSxuYf/Lp0D/FcBU8GkeOo1Sx5xEt8H8bJcErtCe4Blb8JxcW6EXO3sReb4z+zcR07gumPgFITZ6hDA8sSNuvo/AlWg0IKTeZSwHHVknWdQqDJ0uczE837caBxyTZllDNIGkBjCIIOFzuTT76HfYc/7CTTGk07uaNkUFXKN79xDiFOX8JQ1ZZMZvGOTwWjuT9CqgdTvQRORbRWwOYv3MH8re9ykw3Ip6lrPifY7s6hOaAKry/nkGPMt40m1TdiW98MTIpooE7W+WXu96ax2l2OJvxX8QR7l+LFlKnkIEEJd/ItF1G22UmOjkVwNASTwza/hlY+8DoVvEmwum/nMgH2TwQT3bTQzF9s9DOJkH4d8p4Mw4gEDjNx0EgUFA91ysCAeUMQQyIvuR8HXXa+VcvhOOO5mmBcVhxJ3qUOJTyDBsT0932Zb4mNtkxdigoVxu+iiwk0vwtvKwGVDYdyMP5EAQeEIP1t0w== authority@example.com"
     );
     assert_eq!(
-        known_hosts[3].public_key().comment_bytes(),
+        known_hosts[3].public_key().comment().as_bytes(),
         b"authority@example.com"
     );
 }

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -167,7 +167,7 @@ fn validate_dsa(key: PrivateKey) {
         &hex!("0c377ac449e770d89a3557743cbd050396114b62"),
         dsa_keypair.private().as_bytes()
     );
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 }
 
 #[cfg(feature = "p256")]
@@ -217,7 +217,7 @@ fn validate_ecdsa_p256(key: PrivateKey) {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 }
 
 #[cfg(feature = "p384")]
@@ -235,7 +235,7 @@ fn decode_padless_wonder_openssh() {
     assert!(key.kdf().is_none());
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"", key.comment_bytes());
+    assert_eq!(b"", key.comment().as_bytes());
 }
 
 #[cfg(feature = "ed25519")]
@@ -248,7 +248,7 @@ fn decode_overpadded_puttygen_openssh() {
     assert!(key.kdf().is_none());
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"eddsa-key-20241227a1234567890", key.comment_bytes());
+    assert_eq!(b"eddsa-key-20241227a1234567890", key.comment().as_bytes());
 }
 
 #[cfg(feature = "p384")]
@@ -284,7 +284,7 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 }
 
 #[cfg(feature = "p521")]
@@ -321,7 +321,7 @@ fn decode_ecdsa_p521_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 }
 
 #[test]
@@ -360,7 +360,7 @@ fn validate_ed25519(key: PrivateKey) {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(key.comment_bytes(), b"user@example.com");
+    assert_eq!(key.comment().as_bytes(), b"user@example.com");
 }
 
 /// Test alternative PEM line wrappings (64 columns).
@@ -473,7 +473,7 @@ fn validate_rsa_3072(key: PrivateKey) {
         ),
         rsa_keypair.private().q().as_bytes()
     );
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 }
 
 #[cfg(feature = "alloc")]
@@ -555,7 +555,7 @@ fn decode_rsa_4096_openssh() {
         ),
         rsa_keypair.private().q().as_bytes()
     );
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 }
 
 #[cfg(feature = "rsa")]
@@ -593,7 +593,7 @@ fn decode_custom_algorithm_openssh() {
         opaque_keypair.private.as_ref(),
     );
 
-    assert_eq!(key.comment_bytes(), b"comment@example.com");
+    assert_eq!(key.comment().as_bytes(), b"comment@example.com");
 }
 
 #[cfg(feature = "alloc")]
@@ -601,11 +601,11 @@ fn decode_custom_algorithm_openssh() {
 fn round_trip_non_utf8_comment_openssh() {
     let private_key = PrivateKey::from_openssh(OPENSSH_NON_UTF8_COMMENT_EXAMPLE).unwrap();
     assert_eq!(
-        private_key.comment_bytes(),
+        private_key.comment().as_bytes(),
         b"star_@\xB2\xDC\xC8\xF1\xC8\xF1\xC8\xF1\xB5\xC4\xB5\xE7\xC4\xD4"
     );
-    assert_eq!(private_key.comment_str_lossy(), "star_@");
-    assert!(private_key.comment_str().is_err());
+    assert_eq!(private_key.comment().as_str_lossy(), "star_@");
+    assert!(private_key.comment().as_str().is_err());
     assert_eq!(
         &*private_key.to_openssh(Default::default()).unwrap(),
         OPENSSH_NON_UTF8_COMMENT_EXAMPLE

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -94,7 +94,7 @@ fn decode_dsa_openssh() {
         dsa_key.y().as_bytes(),
     );
 
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
     assert_eq!(
         "SHA256:Nh0Me49Zh9fDw/VYUfq43IJmI1T+XrjiYONPND8GzaM",
         &key.fingerprint(Default::default()).to_string(),
@@ -123,7 +123,7 @@ fn decode_ecdsa_p256_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:JQ6FV0rf7qqJHZqIj4zNH8eV0oB8KLKh9Pph3FTD98g",
@@ -154,7 +154,7 @@ fn decode_ecdsa_p384_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:nkGE8oV7pHvOiPKHtQRs67WUPiVLRxbNu//gV/k4Vjw",
@@ -186,7 +186,7 @@ fn decode_ecdsa_p521_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:l3AUUMK6Q2BbuiqvMx2fs97f8LUYq7sWCAx7q5m3S6M",
@@ -205,7 +205,7 @@ fn decode_ed25519_openssh() {
     );
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:UCUiLr7Pjs9wFFJMDByLgc3NrtdU344OgUM45wZPcIQ",
@@ -236,7 +236,7 @@ fn decode_rsa_3072_openssh() {
         ),
         rsa_key.n().as_bytes(),
     );
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
     assert_eq!(
         "SHA256:Fmxts/GcV77PakFnf1Ueki5mpU4ZjUQWGRjZGAo3n/I",
         &key.fingerprint(Default::default()).to_string(),
@@ -269,7 +269,7 @@ fn decode_rsa_4096_openssh() {
         ),
         rsa_key.n().as_bytes(),
     );
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
     assert_eq!(
         "SHA256:FKAyeywtQNZLl1YTzIzCV/ThadBlnWMaD7jHQYDseEY",
         &key.fingerprint(Default::default()).to_string(),
@@ -294,7 +294,7 @@ fn decode_sk_ecdsa_p256_openssh() {
     assert_eq!("ssh:", ecdsa_key.application());
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:UINe2WXFh3SiqwLxsBv34fBO2ei+g7uOeJJXVEK95iE",
@@ -335,7 +335,7 @@ fn decode_sk_ed25519_openssh() {
     assert_eq!("ssh:", ed25519_key.application());
 
     #[cfg(feature = "alloc")]
-    assert_eq!(b"user@example.com", key.comment_bytes());
+    assert_eq!(b"user@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:6WZVJ44bqhAWLVP4Ns0TDkoSQSsZo/h2K+mEvOaNFbw",
@@ -373,7 +373,7 @@ fn decode_custom_algorithm_openssh() {
         opaque_key.as_ref(),
     );
 
-    assert_eq!(b"comment@example.com", key.comment_bytes());
+    assert_eq!(b"comment@example.com", key.comment().as_bytes());
 
     assert_eq!(
         "SHA256:8GV7v5qOHG9invseKCx0NVwFocNL0MwdyRC9bfjTFGs",


### PR DESCRIPTION
Extracts a type which models the concerns of comments, namely that they can be encoded as an RFC4251 `string` type which can hold arbitrary binary data when stored in the binary serialization of a private key.

This replaces the various accessor methods on `PublicKey` and `PrivateKey` for handling the various conversions.