### PR TITLE
ssh-key: temporarily remove `ed25519` feature

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -72,7 +72,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std,ppk --release
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,dsa,getrandom,p256,p384,p521,ppk,rsa,tdes,std --release # TODO: ed25519
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features alloc,crypto,dsa,encryption,tdes --release
 
   test:
@@ -88,7 +88,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std,ppk --release
+      - run: cargo hack test --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,ppk,rsa,tdes,std,ppk --release # TODO: ed25519
       - run: cargo test --release
       - run: cargo test --release --features getrandom
       - run: cargo test --release --features std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,30 +232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?branch=rustcrypto-new-releases#88e1efaae36d4438fd3f17ad3cb043dd3da844d4"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?branch=rustcrypto-new-releases#88e1efaae36d4438fd3f17ad3cb043dd3da844d4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "der"
 version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,26 +294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "3.0.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e01f644da45b2f83a7c40f6895ccc467ce60d6163c729d9fe4351eaa42c512"
-dependencies = [
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0-pre"
-source = "git+https://github.com/dalek-cryptography/curve25519-dalek.git?branch=rustcrypto-new-releases#88e1efaae36d4438fd3f17ad3cb043dd3da844d4"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
- "subtle",
-]
-
-[[package]]
 name = "elliptic-curve"
 version = "0.14.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,12 +321,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "getrandom"
@@ -689,15 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "sec1"
 version = "0.8.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,12 +651,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -839,7 +774,6 @@ dependencies = [
  "argon2",
  "bcrypt-pbkdf",
  "dsa",
- "ed25519-dalek",
  "hex",
  "hex-literal",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ ssh-encoding = { path = "./ssh-encoding" }
 ssh-key = { path = "./ssh-key" }
 
 # https://github.com/dalek-cryptography/curve25519-dalek/pull/676
-ed25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", branch = "rustcrypto-new-releases" }
+#ed25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek.git", branch = "rustcrypto-new-releases" }

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false }
 argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
 bcrypt-pbkdf = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
 dsa = { version = "0.7.0-rc.0", optional = true, default-features = false, features = ["hazmat"] }
-ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
+#ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 hmac = { version = "0.13.0-rc.0", optional = true }
 home = { version = "0.5", optional = true }
@@ -51,10 +51,10 @@ default = ["ecdsa", "rand_core", "std"]
 alloc = ["encoding/alloc", "signature/alloc", "zeroize/alloc", ]
 std = ["alloc", "p256?/std", "p384?/std", "p521?/std", "rsa?/std", "sec1?/std", "dep:home"]
 
-crypto = ["ed25519", "p256", "p384", "p521", "rsa"] # NOTE: `dsa` is obsolete/weak
+crypto = ["p256", "p384", "p521", "rsa"] # ... "ed25519" ] NOTE: `dsa` is obsolete/weak
 dsa = ["dep:dsa", "dep:sha1", "alloc", "encoding/bigint", "signature/rand_core"]
 ecdsa = ["dep:sec1"]
-ed25519 = ["dep:ed25519-dalek", "rand_core"]
+#ed25519 = ["dep:ed25519-dalek", "rand_core"]
 encryption = [
     "dep:bcrypt-pbkdf",
     "alloc",

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -5,6 +5,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
+#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 #![forbid(unsafe_code)]
 #![warn(
     clippy::alloc_instead_of_core,

--- a/ssh-key/tests/certificate.rs
+++ b/ssh-key/tests/certificate.rs
@@ -1,6 +1,7 @@
 //! OpenSSH certificate tests.
 
 #![cfg(feature = "alloc")]
+#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 
 use hex_literal::hex;
 use ssh_key::{Algorithm, Certificate};

--- a/ssh-key/tests/certificate_builder.rs
+++ b/ssh-key/tests/certificate_builder.rs
@@ -1,5 +1,6 @@
 //! Certificate builder tests.
 
+#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 #![cfg(all(
     feature = "alloc",
     feature = "rand_core",

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -1,5 +1,7 @@
 //! SSH private key tests.
 
+#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
+
 use hex_literal::hex;
 use ssh_key::{Algorithm, Cipher, KdfAlg, PrivateKey};
 

--- a/ssh-key/tests/sshsig.rs
+++ b/ssh-key/tests/sshsig.rs
@@ -1,6 +1,7 @@
 //! `sshsig` signature tests.
 
 #![cfg(feature = "alloc")]
+#![allow(unexpected_cfgs)] // `ed25519` is temporarily disabled
 
 use hex_literal::hex;
 use ssh_key::{Algorithm, HashAlg, LineEnding, PublicKey, SshSig};


### PR DESCRIPTION
Again: redo of #249 for another prerelease.

This makes it possible to publish a prerelease, which we otherwise can't do since we're sourcing `ed25519-dalek` from this git branch:

https://github.com/dalek-cryptography/curve25519-dalek/pull/676

This commit can be reverted immediately after we publish a crate release.