### PR TITLE
Use Traits

### DIFF
--- a/ssh-key/src/dot_ssh.rs
+++ b/ssh-key/src/dot_ssh.rs
@@ -72,12 +72,12 @@ impl DotSsh {
 
     /// Write a private key into `~/.ssh`.
     pub fn write_private_key(&self, filename: impl AsRef<Path>, key: &PrivateKey) -> Result<()> {
-        key.write_openssh_file(&self.path.join(filename), Default::default())
+        key.write_openssh_file(self.path.join(filename), Default::default())
     }
 
     /// Write a public key into `~/.ssh`.
     pub fn write_public_key(&self, filename: impl AsRef<Path>, key: &PublicKey) -> Result<()> {
-        key.write_openssh_file(&self.path.join(filename))
+        key.write_openssh_file(self.path.join(filename))
     }
 }
 
@@ -100,7 +100,7 @@ impl Iterator for PrivateKeysIter {
         loop {
             let entry = self.read_dir.next()?.ok()?;
 
-            if let Ok(key) = PrivateKey::read_openssh_file(&entry.path()) {
+            if let Ok(key) = PrivateKey::read_openssh_file(entry.path()) {
                 return Some(key);
             }
         }
@@ -119,7 +119,7 @@ impl Iterator for PublicKeysIter {
         loop {
             let entry = self.read_dir.next()?.ok()?;
 
-            if let Ok(key) = PublicKey::read_openssh_file(&entry.path()) {
+            if let Ok(key) = PublicKey::read_openssh_file(entry.path()) {
                 return Some(key);
             }
         }

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -358,7 +358,7 @@ impl PrivateKey {
 
     /// Write private key as an OpenSSH-formatted PEM file.
     #[cfg(feature = "std")]
-    pub fn write_openssh<W: Write>(&self, mut writer: W, line_ending: LineEnding) -> Result<()> {
+    pub fn write_openssh<W: Write>(&self, writer: &mut W, line_ending: LineEnding) -> Result<()> {
         let pem = self.to_openssh(line_ending)?;
         writer.write_all(pem.as_bytes())?;
         Ok(())

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -366,7 +366,11 @@ impl PrivateKey {
 
     /// Write private key as an OpenSSH-formatted PEM file.
     #[cfg(feature = "std")]
-    pub fn write_openssh_file<P: AsRef<Path>>(&self, path: P, line_ending: LineEnding) -> Result<()> {
+    pub fn write_openssh_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+        line_ending: LineEnding,
+    ) -> Result<()> {
         let pem = self.to_openssh(line_ending)?;
 
         #[cfg(not(unix))]

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -160,8 +160,11 @@ use rand_core::CryptoRngCore;
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
+#[cfg(feature = "std")]
+use std::io::{self, Read, Write};
+
 #[cfg(all(unix, feature = "std"))]
-use std::{io::Write, os::unix::fs::OpenOptionsExt};
+use std::os::unix::fs::OpenOptionsExt;
 
 /// Error message for infallible conversions (used by `expect`)
 const CONVERSION_ERROR_MSG: &str = "SSH private key conversion error";
@@ -340,7 +343,14 @@ impl PrivateKey {
 
     /// Read private key from an OpenSSH-formatted PEM file.
     #[cfg(feature = "std")]
-    pub fn read_openssh_file(path: &Path) -> Result<Self> {
+    pub fn read_openssh<R: Read>(reader: &mut R) -> Result<Self> {
+        let pem = Zeroizing::new(io::read_to_string(reader)?);
+        Self::from_openssh(&*pem)
+    }
+
+    /// Read private key from an OpenSSH-formatted PEM file.
+    #[cfg(feature = "std")]
+    pub fn read_openssh_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         // TODO(tarcieri): verify file permissions match `UNIX_FILE_PERMISSIONS`
         let pem = Zeroizing::new(fs::read_to_string(path)?);
         Self::from_openssh(&*pem)
@@ -348,7 +358,15 @@ impl PrivateKey {
 
     /// Write private key as an OpenSSH-formatted PEM file.
     #[cfg(feature = "std")]
-    pub fn write_openssh_file(&self, path: &Path, line_ending: LineEnding) -> Result<()> {
+    pub fn write_openssh<W: Write>(&self, mut writer: W, line_ending: LineEnding) -> Result<()> {
+        let pem = self.to_openssh(line_ending)?;
+        writer.write_all(pem.as_bytes())?;
+        Ok(())
+    }
+
+    /// Write private key as an OpenSSH-formatted PEM file.
+    #[cfg(feature = "std")]
+    pub fn write_openssh_file<P: AsRef<Path>>(&self, path: P, line_ending: LineEnding) -> Result<()> {
         let pem = self.to_openssh(line_ending)?;
 
         #[cfg(not(unix))]

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -62,6 +62,14 @@ impl PartialEq for DsaPrivateKey {
     }
 }
 
+impl TryFrom<Mpint> for DsaPrivateKey {
+    type Error = Error;
+
+    fn try_from(x: Mpint) -> Result<Self> {
+        Self::new(x)
+    }
+}
+
 impl Decode for DsaPrivateKey {
     type Error = Error;
 

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -88,6 +88,12 @@ impl<const SIZE: usize> Encode for EcdsaPrivateKey<SIZE> {
     }
 }
 
+impl<const SIZE: usize> From<[u8; SIZE]> for EcdsaPrivateKey<SIZE> {
+    fn from(bytes: [u8; SIZE]) -> Self {
+        Self { bytes }
+    }
+}
+
 impl<const SIZE: usize> AsRef<[u8; SIZE]> for EcdsaPrivateKey<SIZE> {
     fn as_ref(&self) -> &[u8; SIZE] {
         &self.bytes

--- a/ssh-key/src/private/opaque.rs
+++ b/ssh-key/src/private/opaque.rs
@@ -77,6 +77,12 @@ impl OpaqueKeypair {
     }
 }
 
+impl From<Vec<u8>> for OpaquePrivateKeyBytes {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
 impl Decode for OpaquePrivateKeyBytes {
     type Error = Error;
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -237,14 +237,14 @@ impl PublicKey {
 
     /// Read public key from an OpenSSH-formatted file.
     #[cfg(feature = "std")]
-    pub fn read_openssh_file(path: &Path) -> Result<Self> {
+    pub fn read_openssh_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let input = fs::read_to_string(path)?;
         Self::from_openssh(&input)
     }
 
     /// Write public key as an OpenSSH-formatted file.
     #[cfg(feature = "std")]
-    pub fn write_openssh_file(&self, path: &Path) -> Result<()> {
+    pub fn write_openssh_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let mut encoded = self.to_openssh()?;
         encoded.push('\n'); // TODO(tarcieri): OS-specific line endings?
 

--- a/ssh-key/src/public.rs
+++ b/ssh-key/src/public.rs
@@ -50,6 +50,9 @@ use serde::{Deserialize, Serialize, de, ser};
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
+#[cfg(feature = "std")]
+use std::io::{self, Read, Write};
+
 #[cfg(doc)]
 use crate::PrivateKey;
 
@@ -237,9 +240,26 @@ impl PublicKey {
 
     /// Read public key from an OpenSSH-formatted file.
     #[cfg(feature = "std")]
+    pub fn read_openssh<R: Read>(reader: &mut R) -> Result<Self> {
+        let input = io::read_to_string(reader)?;
+        Self::from_openssh(&input)
+    }
+
+    /// Read public key from an OpenSSH-formatted file.
+    #[cfg(feature = "std")]
     pub fn read_openssh_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let input = fs::read_to_string(path)?;
         Self::from_openssh(&input)
+    }
+
+    /// Write public key as an OpenSSH-formatted file.
+    #[cfg(feature = "std")]
+    pub fn write_openssh<W: Write>(&self, writer: &mut W) -> Result<()> {
+        let mut encoded = self.to_openssh()?;
+        encoded.push('\n'); // TODO(tarcieri): OS-specific line endings?
+
+        writer.write_all(encoded.as_bytes())?;
+        Ok(())
     }
 
     /// Write public key as an OpenSSH-formatted file.


### PR DESCRIPTION
- Implemented `From` and `TryFrom` traits so that `DsaPrivateKey`, `EcdsaPrivateKey`, and `OpaquePrivateKeyBytes` can be created from bytes without needing the `encoding::Decode` trait (`ssh-key` doesn't export `ssh-encoding`, so I had some issues with this).
- Implemented functions for `PrivateKey` and `PublicKey` using `std::io::{Write, Read}` traits (std only). This allows you to read / write files without needing to provide a path
- Use `AsRef<Path>` instead of `&Path` for `PrivateKey` and `PublicKey`

I'd appreciate it if this could be back-ported to `0.6.x`. The `v0.7.0-rc.0` release isn't working for me.