### PR TITLE
ssh-key: re-export `cipher` and `encoding`

### DIFF
--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -176,8 +176,8 @@ pub use crate::{
     private::PrivateKey,
     public::PublicKey,
 };
-pub use cipher::Cipher;
-pub use encoding::pem::LineEnding;
+pub use cipher::{self, Cipher};
+pub use encoding::{self, pem::LineEnding};
 pub use sha2;
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Provides access to the `ssh-cipher` and `ssh-encoding` crates