### PR TITLE
Bump `crypto-bigint` to v0.7.0-pre.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.4"
+version = "0.7.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
+checksum = "a06a5e703b883b3744ddac8b7c5eade2d800d6559ef99760566f8103e3ad39bf"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.4"
+version = "0.8.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2e6107818886eff6b71fba7a2da3dd11025ebb80f0c9b94ff961168ef629f2"
+checksum = "9843074b9f917c0ae9144eeab6f7cb5c09fe6d4b79807a4aa7aa123d4d5eabd4"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7db0cefc575aba0011f77f56b733d6674b926f64211dca9d7254d47d5c425bb"
+checksum = "a12c57b25e46845fca95dfb84f2dcb891c6215ded42793e124c23c3bba289eae"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca18d8009d96ffc2a8b771c7432338233ffcfa05e4ca410ed77900a2a335a0b"
+checksum = "908741ea702207ae9456173adf9aaa8fffdd3a057e55ca9c77f62a05b9ad08d1"
 dependencies = [
  "der",
  "digest",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.5"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541598dba361b5ba0321caad955ba99ae82a604f4047c4f2743724996abf62f4"
+checksum = "eb5fad57f7e416b8f8e81df65daa6a87e402a4469990fd1ba36a8c79515a5fbf"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42c06f1f28ff328cb76c95cb7aebd6734a8333b98bdac393bdc124d16561dcb"
+checksum = "ce3867083c909bbfd0ae070e20a9bb0f3dbce6f8e1fc4441cc01bda4951eeebe"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7594e57ef1ce505538e5a8e3485a21b930e99701bb65c8ede899a3a8213174"
+checksum = "9c2a36b9f22e1c896fbfab98a101ab203ee5c9141f37380bb42839f23dbb5e00"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.5"
+version = "0.14.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9396e2414ace7de7e0f3d544a5a07f129e39b28b2f08a35b3b7febdea36fd8e9"
+checksum = "760573308d256ce0a5961eef42157c165cdfdc515c19d4a6f5d38fdfcc7804cc"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbeb92947a0d0d4b0cab5e2e6749acc44c81461eb3b1aff4dbb7acd0eb9f0ab"
+checksum = "0ad88338273bf095e74dc9b4fa9e68474980af715d4374ecffae09513ab85f6c"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979936340c6e8b108ad132b395a1682f02a0b179080ed3380320c2c888728429"
+checksum = "c6e217447f8603744210c50e4c065b2e5a66b04f5d8279f33032fdb0fde6fabb"
 dependencies = [
  "elliptic-curve",
 ]
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30f0ad781aea19fe741d7a901b2ad8b4271ac3516e7045b8ecff74e201968fe"
+checksum = "a4825b570bf9949160f598b942df0d6abfa00b71a97c970fdd6e2647439634b8"
 dependencies = [
  "const-oid",
  "crypto-bigint",

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 base64ct = { version = "1.7", optional = true }
-bigint = { package = "crypto-bigint", version = "=0.7.0-pre.4", optional = true, default-features = false, features = ["alloc"] }
+bigint = { package = "crypto-bigint", version = "=0.7.0-pre.5", optional = true, default-features = false, features = ["alloc"] }
 bytes = { version = "1", optional = true, default-features = false }
 digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.3", optional = true }

--- a/ssh-encoding/src/lib.rs
+++ b/ssh-encoding/src/lib.rs
@@ -264,11 +264,3 @@ use alloc::vec::Vec;
 
 #[cfg(feature = "bigint")]
 pub use bigint::BoxedUint as Uint;
-
-/// Non-zero [`Uint`].
-#[cfg(feature = "bigint")]
-pub type NonZeroUint = bigint::NonZero<Uint>;
-
-/// Odd [`Uint`].
-#[cfg(feature = "bigint")]
-pub type OddUint = bigint::Odd<Uint>;

--- a/ssh-encoding/src/mpint.rs
+++ b/ssh-encoding/src/mpint.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 #[cfg(feature = "bigint")]
-use crate::{NonZeroUint, OddUint, Uint};
+use crate::Uint;
 
 #[cfg(feature = "subtle")]
 use subtle::{Choice, ConstantTimeEq};
@@ -208,42 +208,6 @@ impl fmt::UpperHex for Mpint {
 }
 
 #[cfg(feature = "bigint")]
-impl TryFrom<NonZeroUint> for Mpint {
-    type Error = Error;
-
-    fn try_from(uint: NonZeroUint) -> Result<Mpint> {
-        Mpint::try_from(&uint)
-    }
-}
-
-#[cfg(feature = "bigint")]
-impl TryFrom<&NonZeroUint> for Mpint {
-    type Error = Error;
-
-    fn try_from(uint: &NonZeroUint) -> Result<Mpint> {
-        Self::try_from(uint.as_ref())
-    }
-}
-
-#[cfg(feature = "bigint")]
-impl TryFrom<OddUint> for Mpint {
-    type Error = Error;
-
-    fn try_from(uint: OddUint) -> Result<Mpint> {
-        Mpint::try_from(&uint)
-    }
-}
-
-#[cfg(feature = "bigint")]
-impl TryFrom<&OddUint> for Mpint {
-    type Error = Error;
-
-    fn try_from(uint: &OddUint) -> Result<Mpint> {
-        Self::try_from(uint.as_ref())
-    }
-}
-
-#[cfg(feature = "bigint")]
 impl TryFrom<Uint> for Mpint {
     type Error = Error;
 
@@ -263,46 +227,6 @@ impl TryFrom<&Uint> for Mpint {
 }
 
 #[cfg(feature = "bigint")]
-impl TryFrom<Mpint> for NonZeroUint {
-    type Error = Error;
-
-    fn try_from(mpint: Mpint) -> Result<NonZeroUint> {
-        NonZeroUint::try_from(&mpint)
-    }
-}
-
-#[cfg(feature = "bigint")]
-impl TryFrom<&Mpint> for NonZeroUint {
-    type Error = Error;
-
-    fn try_from(mpint: &Mpint) -> Result<NonZeroUint> {
-        let uint = Uint::try_from(mpint)?;
-        NonZeroUint::new(uint)
-            .into_option()
-            .ok_or(Error::MpintEncoding)
-    }
-}
-
-#[cfg(feature = "bigint")]
-impl TryFrom<Mpint> for OddUint {
-    type Error = Error;
-
-    fn try_from(mpint: Mpint) -> Result<OddUint> {
-        OddUint::try_from(&mpint)
-    }
-}
-
-#[cfg(feature = "bigint")]
-impl TryFrom<&Mpint> for OddUint {
-    type Error = Error;
-
-    fn try_from(mpint: &Mpint) -> Result<OddUint> {
-        let uint = Uint::try_from(mpint)?;
-        OddUint::new(uint).into_option().ok_or(Error::MpintEncoding)
-    }
-}
-
-#[cfg(feature = "bigint")]
 impl TryFrom<Mpint> for Uint {
     type Error = Error;
 
@@ -316,14 +240,9 @@ impl TryFrom<&Mpint> for Uint {
     type Error = Error;
 
     fn try_from(mpint: &Mpint) -> Result<Uint> {
+        // TODO(tarcieri): enforce a maximum size?
         let bytes = mpint.as_positive_bytes().ok_or(Error::MpintEncoding)?;
-        let bits_precision = bytes
-            .len()
-            .checked_mul(8)
-            .and_then(|n| u32::try_from(n).ok())
-            .ok_or(Error::MpintEncoding)?;
-
-        Ok(Uint::from_be_slice(bytes, bits_precision)?)
+        Ok(Uint::from_be_slice_vartime(bytes))
     }
 }
 

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -28,16 +28,16 @@ zeroize = { version = "1", default-features = false }
 # optional dependencies
 argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
 bcrypt-pbkdf = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
-dsa = { version = "0.7.0-rc.0", optional = true, default-features = false, features = ["hazmat"] }
+dsa = { version = "0.7.0-rc.1", optional = true, default-features = false, features = ["hazmat"] }
 ed25519-dalek = { version = "=2.2.0-pre", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 hmac = { version = "0.13.0-rc.0", optional = true }
 home = { version = "0.5", optional = true }
-p256 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["ecdsa"] }
-p521 = { version = "0.14.0-pre.5", optional = true, default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.14.0-pre.7", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.14.0-pre.7", optional = true, default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.14.0-pre.7", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.9", optional = true, default-features = false }
-rsa = { version = "0.10.0-rc.0", optional = true, default-features = false, features = ["sha2"] }
+rsa = { version = "0.10.0-rc.1", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.8.0-rc.5", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1.0.16", optional = true }
 sha1 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }

--- a/ssh-key/src/private/dsa.rs
+++ b/ssh-key/src/private/dsa.rs
@@ -136,7 +136,7 @@ impl TryFrom<&dsa::SigningKey> for DsaPrivateKey {
 
     fn try_from(key: &dsa::SigningKey) -> Result<DsaPrivateKey> {
         Ok(DsaPrivateKey {
-            inner: key.x().try_into()?,
+            inner: key.x().as_ref().try_into()?,
         })
     }
 }

--- a/ssh-key/src/private/rsa.rs
+++ b/ssh-key/src/private/rsa.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroize;
 
 #[cfg(feature = "rsa")]
 use {
-    encoding::{OddUint, Uint},
+    encoding::Uint,
     rand_core::CryptoRng,
     rsa::{
         pkcs1v15,
@@ -252,7 +252,7 @@ impl TryFrom<&RsaKeypair> for rsa::RsaPrivateKey {
 
     fn try_from(key: &RsaKeypair) -> Result<rsa::RsaPrivateKey> {
         let ret = rsa::RsaPrivateKey::from_components(
-            OddUint::try_from(key.public.n())?,
+            Uint::try_from(key.public.n())?,
             Uint::try_from(key.public.e())?,
             Uint::try_from(&key.private.d)?,
             vec![

--- a/ssh-key/src/public/dsa.rs
+++ b/ssh-key/src/public/dsa.rs
@@ -5,7 +5,7 @@ use core::hash::{Hash, Hasher};
 use encoding::{CheckedSum, Decode, Encode, Reader, Writer};
 
 #[cfg(feature = "dsa")]
-use encoding::{NonZeroUint, OddUint};
+use encoding::Uint;
 
 /// Digital Signature Algorithm (DSA) public key.
 ///
@@ -119,10 +119,10 @@ impl TryFrom<&DsaPublicKey> for dsa::VerifyingKey {
     type Error = Error;
 
     fn try_from(key: &DsaPublicKey) -> Result<dsa::VerifyingKey> {
-        let p = OddUint::try_from(&key.p)?;
-        let q = NonZeroUint::try_from(&key.q)?;
-        let g = NonZeroUint::try_from(&key.g)?;
-        let y = NonZeroUint::try_from(&key.y)?;
+        let p = Uint::try_from(&key.p)?;
+        let q = Uint::try_from(&key.q)?;
+        let g = Uint::try_from(&key.g)?;
+        let y = Uint::try_from(&key.y)?;
 
         let components = dsa::Components::from_components(p, q, g)?;
         dsa::VerifyingKey::from_components(components, y).map_err(|_| Error::Crypto)
@@ -144,10 +144,10 @@ impl TryFrom<&dsa::VerifyingKey> for DsaPublicKey {
 
     fn try_from(key: &dsa::VerifyingKey) -> Result<DsaPublicKey> {
         Ok(DsaPublicKey {
-            p: key.components().p().try_into()?,
-            q: key.components().q().try_into()?,
-            g: key.components().g().try_into()?,
-            y: key.y().try_into()?,
+            p: key.components().p().as_ref().try_into()?,
+            q: key.components().q().as_ref().try_into()?,
+            g: key.components().g().as_ref().try_into()?,
+            y: key.y().as_ref().try_into()?,
         })
     }
 }

--- a/ssh-key/src/public/rsa.rs
+++ b/ssh-key/src/public/rsa.rs
@@ -139,7 +139,7 @@ impl TryFrom<&rsa::RsaPublicKey> for RsaPublicKey {
 
     fn try_from(key: &rsa::RsaPublicKey) -> Result<RsaPublicKey> {
         let e = Mpint::try_from(key.e())?;
-        let n = Mpint::try_from(key.n())?;
+        let n = Mpint::try_from(key.n().as_ref())?;
         RsaPublicKey::new(e, n)
     }
 }

--- a/ssh-key/src/signature.rs
+++ b/ssh-key/src/signature.rs
@@ -12,7 +12,7 @@ use crate::{private::Ed25519Keypair, public::Ed25519PublicKey};
 #[cfg(feature = "dsa")]
 use {
     crate::{private::DsaKeypair, public::DsaPublicKey},
-    encoding::{NonZeroUint, Uint},
+    encoding::Uint,
     signature::{DigestSigner, DigestVerifier},
 };
 
@@ -389,16 +389,7 @@ impl TryFrom<&Signature> for dsa::Signature {
 
         let r = Uint::from_be_slice(components.0, component_bits)?;
         let s = Uint::from_be_slice(components.1, component_bits)?;
-        let signature = Self::from_components(
-            NonZeroUint::new(r)
-                .into_option()
-                .ok_or(encoding::Error::MpintEncoding)?,
-            NonZeroUint::new(s)
-                .into_option()
-                .ok_or(encoding::Error::MpintEncoding)?,
-        );
-
-        Ok(signature)
+        Ok(Self::from_components(r, s).ok_or(encoding::Error::MpintEncoding)?)
     }
 }
 


### PR DESCRIPTION
...and all of the downstream dependencies needed to upgrade it:

- `dsa`
- `rsa`
- `p256`
- `p384`
- `p521`

This notably includes some changes to `dsa` and `rsa` which eliminate the use of `Odd` and `NonZero` input parameters, putting those checks in the constructor instead.