### PR TITLE
ssh-key: Consistency in Key Read + Write

### DIFF
--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -377,7 +377,7 @@ impl PrivateKey {
         let mut options = File::options();
 
         #[cfg(unix)]
-        let mut options = options.mode(UNIX_FILE_PERMISSIONS);
+        options.mode(UNIX_FILE_PERMISSIONS);
 
         let mut file = options.write(true).create(true).truncate(true).open(path)?;
 


### PR DESCRIPTION
- Replace Generics with `impl` for consistency
- Make File + Path functions use `Read` + `Write` implementations to unify behavior
- Unified Unix + Non-Unix behavior for `PrivateKey::write_openssh_file`