### PR TITLE
ssh-key: add `SshSig` prehash support

### DIFF
--- a/ssh-key/src/error.rs
+++ b/ssh-key/src/error.rs
@@ -9,6 +9,9 @@ use crate::certificate;
 #[cfg(feature = "ppk")]
 use crate::ppk::PpkParseError;
 
+#[cfg(doc)]
+use crate::HashAlg;
+
 /// Result type with `ssh-key`'s [`Error`] as the error type.
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -58,6 +61,9 @@ pub enum Error {
 
     /// Other format encoding errors.
     FormatEncoding,
+
+    /// Provided hash is the wrong size for a given [`HashAlg`].
+    HashSize,
 
     /// Input/output errors.
     #[cfg(feature = "std")]
@@ -112,6 +118,7 @@ impl fmt::Display for Error {
             Error::Encoding(err) => write!(f, "{err}"),
             Error::Encrypted => write!(f, "private key is encrypted"),
             Error::FormatEncoding => write!(f, "format encoding error"),
+            Error::HashSize => write!(f, "hash is the wrong size for the given algorithm"),
             #[cfg(feature = "std")]
             Error::Io(err) => write!(f, "I/O error: {}", std::io::Error::from(*err)),
             Error::Namespace => write!(f, "namespace invalid"),

--- a/ssh-key/src/private.rs
+++ b/ssh-key/src/private.rs
@@ -344,6 +344,21 @@ impl PrivateKey {
         SshSig::sign(self, namespace, hash_alg, msg)
     }
 
+    /// Sign the given message prehash using this private key, returning an [`SshSig`].
+    ///
+    /// These signatures can be produced using `ssh-keygen -Y sign`.
+    ///
+    /// For more information, see [`PrivateKey::sign`].
+    #[cfg(feature = "alloc")]
+    pub fn sign_prehash(
+        &self,
+        namespace: &str,
+        hash_alg: HashAlg,
+        prehash: &[u8],
+    ) -> Result<SshSig> {
+        SshSig::sign_prehash(self, namespace, hash_alg, prehash)
+    }
+
     /// Read private key from an OpenSSH-formatted PEM source.
     #[cfg(feature = "std")]
     pub fn read_openssh(reader: &mut impl Read) -> Result<Self> {


### PR DESCRIPTION
Adds basic support for signing and verifying raw message digests, which can be computed incrementally e.g. over a large file.

Closes #380