### PR TITLE
Bump `hybrid-array` to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01559752fbde7734af628961723aa734aa46351cbf5c9ce41133ad2ae1a09b9"
+checksum = "ac8202ab55fcbf46ca829833f347a82a2a4ce0596f0304ac322c2d100030cd56"
 dependencies = [
  "crypto-common",
  "inout",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
+checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be322be4a73a3a55ad74b9833238e76bfd6034ce69a05c1b41c879f6a3bdca6"
+checksum = "0686ba04dc80c816104c96cd7782b748f6ad58c5dd4ee619ff3258cf68e83d54"
 dependencies = [
  "aead",
  "aes",
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d62242539f39ae10c6654d86121e152344e24329c4adb921d672b6369f47a2"
+checksum = "d911686206fdd816a61ed5226535997149b0fc7726e37fee46f407c9ff82ed87"
 dependencies = [
  "base64ct",
  "blake2",
@@ -59,9 +59,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
 
 [[package]]
 name = "base64ct"
@@ -71,9 +71,9 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc110942d74f151c8944335316ae8d07cfbc4e0282e883c5d20e3ca284b40b0"
+checksum = "b1bf369918379398613de5b595f0f843a9c0eaef8266d33a54fb7f82c69f846e"
 dependencies = [
  "blowfish",
  "pbkdf2",
@@ -88,36 +88,37 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d950855224a23299348898f8a2127860e1afea78df3e51deebb89d1cb2f8f"
+checksum = "1edac47499deef695d9431bf241c75ea29f4cf3dcb78d39e19b31515e4ad3b08"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.3"
+version = "0.4.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee88d14c41bbae2e333f574a27fc73d96fe1039e5a356c20d06a7f2a34cd8e5a"
+checksum = "7e59c1aab3e6c5e56afe1b7e8650be9b5a791cb997bdea449194ae62e4bf8c73"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f960d119fb9f71bf044c0f2f91bf6323d749e7302f3ef110a34cd73a5a0d2"
+checksum = "0f4f049baa079f3b50e74ad3b1fb0585db8ec51f08939671bd6fb4d65886b758"
 dependencies = [
  "byteorder",
  "cipher",
@@ -137,9 +138,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef95f543a56c245d9d0826ccbb34636ee983b3e846eff57bc5fc72e1bce1701"
+checksum = "5dbf9e5b071e9de872e32b73f485e8f644ff47c7011d95476733e7482ee3e5c3"
 dependencies = [
  "cipher",
 ]
@@ -152,9 +153,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e057d7ab0331b90074df7ca698b3361860c20a1d8c8e28f49c01f526e3f3958"
+checksum = "6715ea8ef83a13ae76da6239f97762debdf7f5fa45a638dc9c585423a9cd4834"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -164,10 +165,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4ef774202f1749465fc7cf88d70fc30620e8cacd5429268f4bff7d003bd976"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
+ "block-buffer",
  "crypto-common",
  "inout",
  "zeroize",
@@ -190,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-pre.6"
+version = "0.7.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98dc20cae677f0af161d98f18463804b680f9af060f6dbe6d4249bd7e838bca1"
+checksum = "7c069823f41bdc75e99546bfd59eb1ed27d69dc720e5c949fe502b82926f8448"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -204,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
@@ -224,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f239edce204df0e4503cccef3492552773d1ca4e002659a59ca715f099b45ca1"
+checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
 dependencies = [
  "cipher",
 ]
@@ -259,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2fe0a4fafae25053c19a03fefe040607bda956b4941d692ed9fb9d3c18a3193"
+checksum = "7050e8041c28720851f7db83183195b6acf375bb7bb28e3b86f0fe6cbd69459d"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -269,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8025983b9f9f242e94d459a57b81c571e92e4e1717ca57d092d8a69fc539efa1"
+checksum = "3f51594a70805988feb1c85495ddec0c2052e4fbe59d9c0bb7f94bfc164f4f90"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
+checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -290,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.3"
+version = "0.7.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf953085f7e58b6b26fcaf4bce207638c5ced0334cdc5050e309408e40505747"
+checksum = "6abe56a5fd6e0006b67436d77180898a3792257917e417ab10f17ade085247ec"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -306,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.5"
+version = "0.17.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112839e868b3376c2066506d42331023165d687a7ed38b2ed77f28763d9a7742"
+checksum = "a4aa27d88fe1d40a293286027c9306393094d9b36ccd91f2ac4d647870dc0042"
 dependencies = [
  "der",
  "digest",
@@ -341,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.10"
+version = "0.14.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28ecec37eea07ab976cea93c7ce8b36d561cf161f6767925c1edc51024b0ad3"
+checksum = "3b95fd42abd85018a59f5dbe05551e9eed19edfd1182a415cd98f90ca5af1422"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -387,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df2ef47489983b86b012ce4955b61fcfb1a99a761a1a8c79c3129e722da6795"
+checksum = "4f88107cb02ed63adcc4282942e60c4d09d80208d33b360ce7c729ce6dae1739"
 dependencies = [
  "polyval",
 ]
@@ -419,9 +421,9 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
+checksum = "49e206bca159aebaaed410f5e78b2fe56bfc0dd5b19ecae922813b8556b8b07e"
 dependencies = [
  "digest",
 ]
@@ -437,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+checksum = "6fe39a812f039072707ce38020acbab2f769087952eddd9e2b890f37654b2349"
 dependencies = [
  "typenum",
  "zeroize",
@@ -447,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c774c86bce20ea04abe1c37cf0051c5690079a3a28ef5fdac2a5a0412b3d7d74"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "block-padding",
  "hybrid-array",
@@ -478,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be97a30a85c829fdac914cebb89ef05e109f9e5eb6510f46f623be91bc39ded"
+checksum = "aa93e068b773d56fe26be53accf127d6eb0fde35e4116b7a9276db97b6a50ec9"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -491,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9626bce3d0bf768a28778618e5095131cd32bfca5297b51bbcb4abe7fae62a"
+checksum = "74d17e7d4276af996c6c52de52db4df6b676c5efc3a4269e56c9473edee1786d"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -504,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.9"
+version = "0.14.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1071ec0ddc9a8c198692acf5620176b0cd9c1db988acef030e101f851405f4"
+checksum = "2a70f4308991bf35f1632d55155c3ca137f9ce05c6de00be51705bbaa3451cfe"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -529,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.0"
+version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2efb182a4d7d26aa7442a4ef2f91c5021c6abb61f9fdd251fcc2e327f5faaf6"
+checksum = "ca3fc18bb4460ac250ba6b75dfa7cf9d0b2273e3e623f660bd6ce2c3e902342e"
 dependencies = [
  "digest",
 ]
@@ -547,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc2072a7f2eb76d8cb988195d48046451ea2c3dc98a5bbe1b112b70e1cffa60"
+checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
 dependencies = [
  "cpufeatures",
  "universal-hash",
@@ -558,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff52e661730d7c6f95a72137e812e337eb5ff371d38d8588798e0df8404e610c"
+checksum = "1ffd40cc99d0fbb02b4b3771346b811df94194bc103983efa0203c8893755085"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -578,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-pre.4"
+version = "0.14.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
+checksum = "049f40103b7e4b0da4e20ed8556805efa740f7104c48991c5f9ab8e09e10ee21"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -591,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.7"
+version = "0.14.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
+checksum = "9257332cf7e56fa8183f719977b92f1878cb1447275d0ee280a08bcd6fad158f"
 dependencies = [
  "elliptic-curve",
 ]
@@ -643,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53f124bf3ec90be84ae97d7f52175ba938898525554c13c9017eb8f0a604146"
+checksum = "d369f9c4f79388704648e7bcb92749c0d6cf4397039293a9b747694fa4fb4bae"
 dependencies = [
  "hmac",
  "subtle",
@@ -653,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8cb237ca3624409eda7d73de0d423815c9d91175ed5a62a8dd6549d2408cc2"
+checksum = "12c09fc7922fb8b7de31cc809df908e30e0ed46eb33046c6e1e438ef8ec3466b"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -679,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.8"
+version = "0.8.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54dee398d74b1d03d78ddc09c90e456bf906b5b7aa790ba4f48b025b2179e5d"
+checksum = "f5e67a3c9fb9a8f065af9fa30d65812fcc16a66cbf911eff1f6946957ce48f16"
 dependencies = [
  "base16ct",
  "der",
@@ -718,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
 dependencies = [
  "base16ct",
  "serde",
@@ -728,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
+checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -739,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
+checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -750,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.2"
+version = "3.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4835c3b5ecb10171941a4998a95a3a76ecac1c5ae8e6954f2ad030acd1c7e8ab"
+checksum = "39195ff4c0dc41c93e123825ca1f0d11b856df8b26d5fe140a522355632c4345"
 dependencies = [
  "digest",
  "rand_core",
@@ -870,9 +872,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17866ce72039aaa929b785c51d08d0395e02cb5eaffd3efdf634b9b1f80b8157"
+checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -19,18 +19,18 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 encoding = { package = "ssh-encoding", version = "0.3.0-rc.1" }
 
 # optional dependencies
-aead = { version = "0.6.0-rc.1", optional = true, default-features = false }
-aes = { version = "0.9.0-rc.0", optional = true, default-features = false }
-aes-gcm = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["aes"] }
-cbc = { version = "0.2.0-rc.0", optional = true }
-ctr = { version = "0.10.0-rc.0", optional = true, default-features = false }
-chacha20 = { version = "0.10.0-rc.0", optional = true, default-features = false, features = ["cipher", "legacy"] }
-des = { version = "0.9.0-rc.0", optional = true, default-features = false }
-poly1305 = { version = "0.9.0-rc.1", optional = true, default-features = false }
+aead = { version = "0.6.0-rc.2", optional = true, default-features = false }
+aes = { version = "0.9.0-rc.1", optional = true, default-features = false }
+aes-gcm = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["aes"] }
+cbc = { version = "0.2.0-rc.1", optional = true }
+ctr = { version = "0.10.0-rc.1", optional = true, default-features = false }
+chacha20 = { version = "0.10.0-rc.1", optional = true, default-features = false, features = ["cipher", "legacy"] }
+des = { version = "0.9.0-rc.1", optional = true, default-features = false }
+poly1305 = { version = "0.9.0-rc.2", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -17,9 +17,9 @@ rust-version = "1.85"
 
 [dependencies]
 base64ct = { version = "1.7", optional = true }
-bigint = { package = "crypto-bigint", version = "=0.7.0-pre.6", optional = true, default-features = false, features = ["alloc"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.4", optional = true, default-features = false, features = ["alloc"] }
 bytes = { version = "1", optional = true, default-features = false }
-digest = { version = "0.11.0-rc.0", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.1", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.3", optional = true }
 ssh-derive = { version = "0.3.0-rc.0", optional = true }
 subtle = { version = "2", optional = true, default-features = false }

--- a/ssh-encoding/tests/derive.rs
+++ b/ssh-encoding/tests/derive.rs
@@ -4,7 +4,7 @@
 use ssh_encoding::{Decode, Encode, Error};
 
 #[derive(Debug, PartialEq, Decode, Encode)]
-struct MostTypes<T>
+pub struct MostTypes<T>
 where
     T: Encode + Decode<Error = Error>,
 {
@@ -21,11 +21,11 @@ where
 
 // Only `Encode` is derived for references, as `Decode` isn't implemented for them.
 #[derive(Debug, PartialEq, Encode)]
-struct Reference<'a>(&'a [u8]);
+pub struct Reference<'a>(&'a [u8]);
 
 #[derive(Debug, PartialEq, Decode, Encode)]
 #[ssh(length_prefixed)]
-struct LengthPrefixed {
+pub struct LengthPrefixed {
     #[ssh(length_prefixed)]
     a: u32,
     b: String,
@@ -34,7 +34,7 @@ struct LengthPrefixed {
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[repr(u8)]
 #[ssh(length_prefixed)]
-enum ComplexEnum {
+pub enum ComplexEnum {
     Bar = 1,
     Baz {
         a: u32,
@@ -46,20 +46,20 @@ enum ComplexEnum {
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[repr(u32)]
-enum SimpleEnum {
+pub enum SimpleEnum {
     A = 1,
     B = 2,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 #[repr(u8)]
-enum ModerateEnum {
+pub enum ModerateEnum {
     A = 1,
     B { a: String } = 2,
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
-struct Empty;
+pub struct Empty;
 
 #[test]
 fn derive_encode_decode_roundtrip_most_types() {

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -20,27 +20,27 @@ rust-version = "1.85"
 [dependencies]
 cipher = { package = "ssh-cipher", version = "0.3.0-rc.2", features = ["zeroize"] }
 encoding = { package = "ssh-encoding", version = "0.3.0-rc.1", features = ["base64", "digest", "pem", "subtle", "zeroize"] }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
-signature = { version = "3.0.0-rc.2", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
+signature = { version = "3.0.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
-bcrypt-pbkdf = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["alloc"] }
-dsa = { version = "0.7.0-rc.3", optional = true, default-features = false, features = ["hazmat"] }
+argon2 = { version = "0.6.0-rc.1", optional = true, default-features = false, features = ["alloc"] }
+bcrypt-pbkdf = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["alloc"] }
+dsa = { version = "0.7.0-rc.4", optional = true, default-features = false, features = ["hazmat"] }
 ed25519-dalek = { version = "=3.0.0-pre.0", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
-hmac = { version = "0.13.0-rc.0", optional = true }
+hmac = { version = "0.13.0-rc.1", optional = true }
 home = { version = "0.5", optional = true }
-p256 = { version = "0.14.0-pre.9", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.14.0-pre.9", optional = true, default-features = false, features = ["ecdsa"] }
-p521 = { version = "0.14.0-pre.9", optional = true, default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.14.0-pre.10", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.14.0-pre.10", optional = true, default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.14.0-pre.10", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.9", optional = true, default-features = false }
-rsa = { version = "0.10.0-rc.3", optional = true, default-features = false, features = ["sha2"] }
-sec1 = { version = "0.8.0-rc.6", optional = true, default-features = false, features = ["point"] }
+rsa = { version = "0.10.0-rc.6", optional = true, default-features = false, features = ["sha2"] }
+sec1 = { version = "0.8.0-rc.9", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1.0.16", optional = true }
-sha1 = { version = "0.11.0-rc.0", optional = true, default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["oid"] }
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
This commit bumps pretty much every algorithm dependency to the latest versions, which have switched from `hybrid-array` v0.3 to v0.4.