### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-cipher"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "aead",
  "aes",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-encoding"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "base64ct",
  "bytes",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 dependencies = [
  "argon2",
  "bcrypt-pbkdf",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-cipher"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 description = """
 Pure Rust implementation of SSH symmetric encryption including support for the
 modern aes128-gcm@openssh.com/aes256-gcm@openssh.com and
@@ -20,7 +20,7 @@ rust-version = "1.85"
 
 [dependencies]
 cipher = "0.5.0-rc.1"
-encoding = { package = "ssh-encoding", version = "0.3.0-rc.1" }
+encoding = { package = "ssh-encoding", version = "0.3.0-rc.2" }
 
 # optional dependencies
 aead = { version = "0.6.0-rc.2", optional = true, default-features = false }

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-encoding"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 description = """
 Pure Rust implementation of SSH data type decoders/encoders as described
 in RFC4251

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-key"
-version = "0.7.0-rc.1"
+version = "0.7.0-rc.2"
 description = """
 Pure Rust implementation of SSH key file format decoders/encoders as described
 in RFC4251/RFC4253 and OpenSSH key formats, as well as "sshsig" signatures and
@@ -18,8 +18,8 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-cipher = { package = "ssh-cipher", version = "0.3.0-rc.2", features = ["zeroize"] }
-encoding = { package = "ssh-encoding", version = "0.3.0-rc.1", features = ["base64", "digest", "pem", "subtle", "zeroize"] }
+cipher = { package = "ssh-cipher", version = "0.3.0-rc.3", features = ["zeroize"] }
+encoding = { package = "ssh-encoding", version = "0.3.0-rc.2", features = ["base64", "digest", "pem", "subtle", "zeroize"] }
 sha2 = { version = "0.11.0-rc.2", default-features = false }
 signature = { version = "3.0.0-rc.3", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/ssh-protocol/Cargo.toml
+++ b/ssh-protocol/Cargo.toml
@@ -16,9 +16,9 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-cipher = { package = "ssh-cipher", version = "0.3.0-rc.2", default-features = false }
-encoding = { package = "ssh-encoding", version = "0.3.0-rc.1", default-features = false }
-key = { package = "ssh-key", version = "0.7.0-rc.0", default-features = false }
+cipher = { package = "ssh-cipher", version = "0.3.0-rc.3", default-features = false }
+encoding = { package = "ssh-encoding", version = "0.3.0-rc.2", default-features = false }
+key = { package = "ssh-key", version = "0.7.0-rc.2", default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Releases the following:
- `ssh-cipher` v0.3.0-rc.3
- `ssh-encoding` v0.3.0-rc.2
- `ssh-key` v0.7.0-rc.2