### PR TITLE
ssh-key: use `std::env::home_dir` instead of `home` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,15 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,7 +810,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
- "home",
  "p256",
  "p384",
  "p521",
@@ -902,79 +892,6 @@ checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -32,7 +32,6 @@ dsa = { version = "0.7.0-rc.6", optional = true, default-features = false, featu
 ed25519-dalek = { version = "=3.0.0-pre.1", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 hmac = { version = "0.13.0-rc.2", optional = true }
-home = { version = "0.5", optional = true }
 p256 = { version = "0.14.0-pre.11", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.14.0-pre.11", optional = true, default-features = false, features = ["ecdsa"] }
 p521 = { version = "0.14.0-pre.11", optional = true, default-features = false, features = ["ecdsa"] }
@@ -49,7 +48,7 @@ rand_chacha = "0.9"
 [features]
 default = ["ecdsa", "rand_core", "std"]
 alloc = ["encoding/alloc", "signature/alloc", "zeroize/alloc", ]
-std = ["alloc", "dep:home"]
+std = ["alloc"]
 
 crypto = ["ed25519", "p256", "p384", "p521", "rsa"] # NOTE: `dsa` is obsolete/weak
 dsa = ["dep:dsa", "dep:sha1", "alloc", "encoding/bigint", "signature/rand_core"]

--- a/ssh-key/src/dot_ssh.rs
+++ b/ssh-key/src/dot_ssh.rs
@@ -2,6 +2,7 @@
 
 use crate::{Fingerprint, PrivateKey, PublicKey, Result};
 use std::{
+    env,
     fs::{self, ReadDir},
     path::{Path, PathBuf},
 };
@@ -17,7 +18,8 @@ impl DotSsh {
     ///
     /// Returns `None` if the home directory couldn't be located.
     pub fn new() -> Option<Self> {
-        home::home_dir().map(|path| Self::open(path.join(".ssh")))
+        #[allow(deprecated)] // NOTE: no longer deprecated as of Rust 1.86
+        env::home_dir().map(|path| Self::open(path.join(".ssh")))
     }
 
     /// Open a `~/.ssh`-structured directory.


### PR DESCRIPTION
Prior to Rust 1.86, `std::env::home_dir` was deprecated in favor of the `home` crate. However, Rust 1.86 fixed the behavior of the function on Windows to use the `USERPROFILE` environment variable with a fallback to `GetUserProfileDirectory`, meaning we no longer need to use a crate for this purpose.

Also, `home` now has an MSRV of 1.88, which would complicate our plans to launch with an MSRV of 1.85 (see #413).