### PR TITLE
Bump `rand_core` to v0.10.0-rc-2

### DIFF
--- a/.github/workflows/ssh-key.yml
+++ b/.github/workflows/ssh-key.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset --exclude-features default,dsa,ed25519,getrandom,p256,p384,p521,rsa,tdes,std,ppk --release
       - run: cargo test --release
-      - run: cargo test --release --features getrandom
+      #- run: cargo test --release --features getrandom # TODO(tarcieri): fix `getrandom` feature
       - run: cargo test --release --features std
       - run: cargo test --all-features # debug build
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8202ab55fcbf46ca829833f347a82a2a4ce0596f0304ac322c2d100030cd56"
+checksum = "03d2d54c4d9e7006f132f615a167865bff927a79ca63d8f637237575ce0a9795"
 dependencies = [
  "crypto-common",
  "inout",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
+checksum = "fd9e1c818b25efb32214df89b0ec22f01aa397aaeb718d1022bf0635a3bfd1a8"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686ba04dc80c816104c96cd7782b748f6ad58c5dd4ee619ff3258cf68e83d54"
+checksum = "7f5c07f414d7dc0755870f84c7900425360288d24e0eae4836f9dee19a30fa5f"
 dependencies = [
  "aead",
  "aes",
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d911686206fdd816a61ed5226535997149b0fc7726e37fee46f407c9ff82ed87"
+checksum = "e1a213fe583d472f454ae47407edc78848bebd950493528b1d4f7327a7dc335f"
 dependencies = [
  "base64ct",
  "blake2",
@@ -71,9 +71,9 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf369918379398613de5b595f0f843a9c0eaef8266d33a54fb7f82c69f846e"
+checksum = "5f0a790efa000ecb138276d4da57f782c0e6bb60d59150105290d6ec8cfeb2c2"
 dependencies = [
  "blowfish",
  "pbkdf2",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edac47499deef695d9431bf241c75ea29f4cf3dcb78d39e19b31515e4ad3b08"
+checksum = "679065eb2b85a078ace42411e657bef3a6afe93a40d1b9cb04e39ca303cc3f36"
 dependencies = [
  "digest",
 ]
@@ -101,18 +101,18 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e59c1aab3e6c5e56afe1b7e8650be9b5a791cb997bdea449194ae62e4bf8c73"
+checksum = "41d28ed5f5f65056148fd25e1a596b5b6d9e772270abf9a9085d7cbfbf26c563"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4f049baa079f3b50e74ad3b1fb0585db8ec51f08939671bd6fb4d65886b758"
+checksum = "8ecfb049d43f70154a8a232d709710dc7350bda1fa7d0e539a252f0938adad8e"
 dependencies = [
  "byteorder",
  "cipher",
@@ -132,9 +132,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbf9e5b071e9de872e32b73f485e8f644ff47c7011d95476733e7482ee3e5c3"
+checksum = "3c34a745c272d1f6124df3006881364190a8f033ff3857ce196a17aa4a753096"
 dependencies = [
  "cipher",
 ]
@@ -147,21 +147,22 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.2"
+version = "0.10.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd162f2b8af3e0639d83f28a637e4e55657b7a74508dba5a9bf4da523d5c9e9"
+checksum = "99cbf41c6ec3c4b9eaf7f8f5c11a72cd7d3aa0428125c20d5ef4d09907a0f019"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "rand_core",
  "zeroize",
 ]
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
+checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -186,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.8"
+version = "0.7.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4113edbc9f68c0a64d5b911f803eb245d04bb812680fd56776411f69c670f3e0"
+checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
 dependencies = [
  "hybrid-array",
  "num-traits",
@@ -200,18 +201,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.3"
+version = "0.7.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f2523fbb68811c8710829417ad488086720a6349e337c38d12fa81e09e50bf"
+checksum = "fdd9b2855017318a49714c07ee8895b89d3510d54fa6d86be5835de74c389609"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -220,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e41d01c6f73b9330177f5cf782ae5b581b5f2c7840e298e0275ceee5001434"
+checksum = "3d0ec605a95e78815a4c4b8040217d56d5a1ab37043851ee9e7e65b89afa00e3"
 dependencies = [
  "cipher",
 ]
@@ -265,18 +266,18 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.9.0-rc.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f51594a70805988feb1c85495ddec0c2052e4fbe59d9c0bb7f94bfc164f4f90"
+checksum = "512ca722eff02fa73c43e5136f440c46f861d41f9dd7761c1f2817a5ca5d9ad7"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -286,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "dsa"
-version = "0.7.0-rc.6"
+version = "0.7.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc32699f8072355748222f5e28c4ff891ba9036bbd0ed2637fa57ce262238533"
+checksum = "f295219d1be8126f3767cefe40e01434224dede6f6337620622dc3294298322a"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.7"
+version = "0.17.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ab355ec063f7a110eb627471058093aba00eb7f4e70afbd15e696b79d1077b"
+checksum = "b56e025680b64794fad81dd46019037773eeb5268a990c5d4cca05bf351c7f0f"
 dependencies = [
  "der",
  "digest",
@@ -316,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef49c0b20c0ad088893ad2a790a29c06a012b3f05bcfc66661fd22a94b32129"
+checksum = "594435fe09e345ee388e4e8422072ff7dfeca8729389fbd997b3f5504c44cd47"
 dependencies = [
  "signature",
 ]
@@ -326,8 +327,7 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "3.0.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek?branch=rand_core%2Fv0.10-rc#07744fd3fc2671c5f24d9436b3aa01118afca745"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -337,9 +337,8 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae7ba52b8bca06caab3e74b7cf8858a2934e6e75d80b03dbe48d2d394a4489c"
+version = "0.14.0-rc.16"
+source = "git+https://github.com/RustCrypto/traits#2cf79f8c72ff2dba3615c4773fef8e9de5d9909b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -356,8 +355,7 @@ dependencies = [
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
+source = "git+https://github.com/tarcieri/ff?branch=rand_core%2Fv0.10.0-rc-2#470e52fa35f7f6cb59f1f005003a14ac50b50cfd"
 dependencies = [
  "rand_core",
  "subtle",
@@ -370,22 +368,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi",
-]
-
-[[package]]
 name = "ghash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f88107cb02ed63adcc4282942e60c4d09d80208d33b360ce7c729ce6dae1739"
+checksum = "333de57ed9494a40df4bbb866752b100819dde0d18f2264c48f5a08a85fe673d"
 dependencies = [
  "polyval",
 ]
@@ -393,8 +379,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+source = "git+https://github.com/tarcieri/group?branch=rand_core%2Fv0.10.0-rc-2#50640b46d5f7eff37aee24d76e991c18444f372e"
 dependencies = [
  "ff",
  "rand_core",
@@ -415,9 +400,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hmac"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
+checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
  "digest",
 ]
@@ -435,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
+checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
 dependencies = [
  "block-padding",
  "hybrid-array",
@@ -466,9 +451,8 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b374901df34ee468167a58e2a49e468cb059868479cafebeb804f6b855423d"
+version = "0.14.0-rc.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#472a0562a506e4d2479e2d28a5078cfc137c06bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -479,9 +463,8 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701032b3730df6b882496d6cee8221de0ce4bc11ddc64e6d89784aa5b8a6de30"
+version = "0.14.0-rc.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#472a0562a506e4d2479e2d28a5078cfc137c06bb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -493,9 +476,8 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ba29c2906eb5c89a8c411c4f11243ee4e5517ee7d71d9a13fedc877a6057b1"
+version = "0.14.0-rc.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#472a0562a506e4d2479e2d28a5078cfc137c06bb"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -507,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee14c44aa1c04c22c4d4532c4fa2cdd5b6d31c2514a5898530d889fc2fc2737"
+checksum = "a7d47a2d1aee5a339aa6c740d9128211a8a3d2bdf06a13e01b3f8a0b5c49b9db"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -518,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.1"
+version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3fc18bb4460ac250ba6b75dfa7cf9d0b2273e3e623f660bd6ce2c3e902342e"
+checksum = "5f4c07efb9394d8d0057793c35483868c2b8102e287e9d2d4328da0da36bcb4d"
 dependencies = [
  "digest",
 ]
@@ -536,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
+checksum = "d9c0749ae91cfe6e68c77c4d48802d9720ee06aed3f7100a38975fb0962d50bc"
 dependencies = [
  "cpufeatures",
  "universal-hash",
@@ -547,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.0-rc.2"
+version = "0.7.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffd40cc99d0fbb02b4b3771346b811df94194bc103983efa0203c8893755085"
+checksum = "1ad60831c19edda4b20878a676595c357e93a9b4e6dca2ba98d75b01066b317b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -557,19 +539,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "primefield"
-version = "0.14.0-pre.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcd4a163053332fd93f39b81c133e96a98567660981654579c90a99062fbf5"
+version = "0.14.0-rc.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#472a0562a506e4d2479e2d28a5078cfc137c06bb"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -580,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.9"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c36e8766fcd270fa9c665b9dc364f570695f5a59240949441b077a397f15b74"
+checksum = "36714e8f5443e0cc1497f71972788dd95f75bf7253a4393c9f33f3ff9f556cc9"
 dependencies = [
  "elliptic-curve",
 ]
@@ -606,35 +578,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.10.0-rc-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom",
-]
+checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369f9c4f79388704648e7bcb92749c0d6cf4397039293a9b747694fa4fb4bae"
+checksum = "63b8e2323084c987a72875b2fd682b7307d5cf14d47e3875bb5e89948e8809d4"
 dependencies = [
  "hmac",
  "subtle",
@@ -642,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.9"
+version = "0.10.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8955ab399f6426998fde6b76ae27233cce950705e758a6c17afd2f6d0e5d52"
+checksum = "e499c52862d75a86c0024cc99dcb6d7127d15af3beae7b03573d62fab7ade08a"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -726,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
+checksum = "aa1ae819b9870cadc959a052363de870944a1646932d274a4e270f64bf79e5ef"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -737,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -748,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
+checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
 dependencies = [
  "digest",
  "rand_core",
@@ -805,6 +758,7 @@ version = "0.7.0-rc.3"
 dependencies = [
  "argon2",
  "bcrypt-pbkdf",
+ "chacha20",
  "dsa",
  "ed25519-dalek",
  "hex",
@@ -813,7 +767,6 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_chacha",
  "rand_core",
  "rsa",
  "sec1",
@@ -867,56 +820,12 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
+checksum = "9ad6682ddb0189a4d3c2a5c54b8920ab6231ae911db53fc61a0709507bf1713b"
 dependencies = [
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "wasi"
-version = "0.14.5+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ ssh-cipher = { path = "./ssh-cipher" }
 ssh-derive = { path = "./ssh-derive" }
 ssh-encoding = { path = "./ssh-encoding" }
 ssh-key = { path = "./ssh-key" }
+
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", branch = "rand_core/v0.10-rc" }
+elliptic-curve = { git = "https://github.com/RustCrypto/traits" }
+ff = { git = "https://github.com/tarcieri/ff", branch = "rand_core/v0.10.0-rc-2" }
+group = { git = "https://github.com/tarcieri/group", branch = "rand_core/v0.10.0-rc-2" }
+p256 = { git = "https://github.com/RustCrypto/elliptic-curves" }
+p384 = { git = "https://github.com/RustCrypto/elliptic-curves" }
+p521 = { git = "https://github.com/RustCrypto/elliptic-curves" }
+primefield = { git = "https://github.com/RustCrypto/elliptic-curves " }

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -23,14 +23,14 @@ cipher = "0.5.0-rc.1"
 encoding = { package = "ssh-encoding", version = "0.3.0-rc.2" }
 
 # optional dependencies
-aead = { version = "0.6.0-rc.2", optional = true, default-features = false }
-aes = { version = "0.9.0-rc.1", optional = true, default-features = false }
-aes-gcm = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["aes"] }
-cbc = { version = "0.2.0-rc.1", optional = true }
-ctr = { version = "0.10.0-rc.1", optional = true, default-features = false }
-chacha20 = { version = "0.10.0-rc.2", optional = true, default-features = false, features = ["cipher", "legacy"] }
-des = { version = "0.9.0-rc.1", optional = true, default-features = false }
-poly1305 = { version = "0.9.0-rc.2", optional = true, default-features = false }
+aead = { version = "0.6.0-rc.3", optional = true, default-features = false }
+aes = { version = "0.9.0-rc.2", optional = true, default-features = false }
+aes-gcm = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["aes"] }
+cbc = { version = "0.2.0-rc.2", optional = true }
+ctr = { version = "0.10.0-rc.2", optional = true, default-features = false }
+chacha20 = { version = "0.10.0-rc.5", optional = true, default-features = false, features = ["cipher", "legacy"] }
+des = { version = "0.9.0-rc.2", optional = true, default-features = false }
+poly1305 = { version = "0.9.0-rc.3", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -17,9 +17,9 @@ rust-version = "1.85"
 
 [dependencies]
 base64ct = { version = "1.7", optional = true }
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.6", optional = true, default-features = false, features = ["alloc"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.10", optional = true, default-features = false, features = ["alloc"] }
 bytes = { version = "1", optional = true, default-features = false }
-digest = { version = "0.11.0-rc.3", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
 pem-rfc7468 = { version = "1.0.0-rc.3", optional = true }
 ssh-derive = { version = "0.3.0-rc.0", optional = true }
 subtle = { version = "2", optional = true, default-features = false }

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -20,30 +20,30 @@ rust-version = "1.85"
 [dependencies]
 cipher = { package = "ssh-cipher", version = "0.3.0-rc.3", features = ["zeroize"] }
 encoding = { package = "ssh-encoding", version = "0.3.0-rc.2", features = ["base64", "digest", "pem", "subtle", "zeroize"] }
-sha2 = { version = "0.11.0-rc.2", default-features = false }
-signature = { version = "3.0.0-rc.4", default-features = false }
+sha2 = { version = "0.11.0-rc.3", default-features = false }
+signature = { version = "3.0.0-rc.5", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.1", optional = true, default-features = false, features = ["alloc"] }
-bcrypt-pbkdf = { version = "0.11.0-rc.1", optional = true, default-features = false, features = ["alloc"] }
-dsa = { version = "0.7.0-rc.6", optional = true, default-features = false, features = ["hazmat"] }
+argon2 = { version = "0.6.0-rc.2", optional = true, default-features = false, features = ["alloc"] }
+bcrypt-pbkdf = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["alloc"] }
+dsa = { version = "0.7.0-rc.7", optional = true, default-features = false, features = ["hazmat"] }
 ed25519-dalek = { version = "=3.0.0-pre.1", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
-hmac = { version = "0.13.0-rc.2", optional = true }
-p256 = { version = "0.14.0-pre.11", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.14.0-pre.11", optional = true, default-features = false, features = ["ecdsa"] }
-p521 = { version = "0.14.0-pre.11", optional = true, default-features = false, features = ["ecdsa"] }
-rand_core = { version = "0.9", optional = true, default-features = false }
-rsa = { version = "0.10.0-rc.9", optional = true, default-features = false, features = ["sha2"] }
+hmac = { version = "0.13.0-rc.3", optional = true }
+p256 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.14.0-rc.0", optional = true, default-features = false, features = ["ecdsa"] }
+rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
+rsa = { version = "0.10.0-rc.10", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.8.0-rc.10", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1.0.16", optional = true }
-sha1 = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["oid"] }
+sha1 = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["oid"] }
 
 [dev-dependencies]
 hex-literal = "1"
-rand_chacha = "0.9"
+chacha20 = { version = "0.10.0-rc.5", features = ["rng"] }
 
 [features]
 default = ["ecdsa", "rand_core", "std"]
@@ -63,7 +63,6 @@ encryption = [
     "cipher/chacha20poly1305",
     "rand_core"
 ]
-getrandom = ["rand_core/os_rng"] # TODO(tarcieri): rename feature
 p256 = ["dep:p256", "ecdsa"]
 p384 = ["dep:p384", "ecdsa"]
 p521 = ["dep:p521", "ecdsa"]

--- a/ssh-key/src/lib.rs
+++ b/ssh-key/src/lib.rs
@@ -20,6 +20,8 @@
     unused_lifetimes,
     unused_qualifications
 )]
+// TODO(tarcieri): fix `getrandom` feature
+#![allow(unexpected_cfgs)]
 
 //! ## Usage
 //!

--- a/ssh-key/tests/certificate_builder.rs
+++ b/ssh-key/tests/certificate_builder.rs
@@ -6,8 +6,8 @@
     any(feature = "ed25519", feature = "p256")
 ))]
 
+use chacha20::{ChaCha8Rng, rand_core::SeedableRng};
 use hex_literal::hex;
-use rand_chacha::{ChaCha8Rng, rand_core::SeedableRng};
 use ssh_key::{Algorithm, PrivateKey, certificate};
 
 #[cfg(feature = "p256")]

--- a/ssh-key/tests/encrypted_private_key.rs
+++ b/ssh-key/tests/encrypted_private_key.rs
@@ -1,6 +1,8 @@
 //! Encrypted SSH private key tests.
 
 #![cfg(feature = "alloc")]
+// TODO(tarcieri): fix `getrandom` feature
+#![allow(unexpected_cfgs)]
 
 use hex_literal::hex;
 use ssh_key::{Algorithm, Cipher, Kdf, KdfAlg, PrivateKey};


### PR DESCRIPTION
This also accordingly bumps all of the underlying crates to versions which (transitively) depend on the `rand`/`rand_core` v0.10 release series.

The `ssh-key` crate's `getrandom` feature has been temporarily disabled to simplify the upgrade.