### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d2d54c4d9e7006f132f615a167865bff927a79ca63d8f637237575ce0a9795"
+checksum = "67a578e7d4edaef88aeb9cdd81556f4a62266ce26601317c006a79e8bc58b5af"
 dependencies = [
  "crypto-common",
  "inout",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -147,9 +147,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0-rc.5"
+version = "0.10.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cbf41c6ec3c4b9eaf7f8f5c11a72cd7d3aa0428125c20d5ef4d09907a0f019"
+checksum = "f895fb33c1ad22da4bc79d37c0bddff8aee2ba4575705345eb73b8ffbc386074"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -160,15 +160,21 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
+checksum = "98d708bac5451350d56398433b19a7889022fa9187df1a769c0edbc3b2c03167"
 dependencies = [
  "block-buffer",
  "crypto-common",
  "inout",
  "zeroize",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
 
 [[package]]
 name = "const-oid"
@@ -187,10 +193,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.10"
+version = "0.7.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6715836b4946e8585016e80b79c7561476aff3b22f7b756778e7b109d86086c6"
+checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
 dependencies = [
+ "ctutils",
  "hybrid-array",
  "num-traits",
  "rand_core",
@@ -201,18 +208,17 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
+checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd9b2855017318a49714c07ee8895b89d3510d54fa6d86be5835de74c389609"
+version = "0.7.0-dev"
+source = "git+https://github.com/tarcieri/crypto-primes?branch=crypto-bigint%2Fv0.7.0-rc.13#f98697886371aa15446ca53ef5b9e9e44efbabf8"
 dependencies = [
  "crypto-bigint",
  "libm",
@@ -229,10 +235,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "5.0.0-pre.3"
+name = "ctutils"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92419e1cdc506051ffd30713ad09d0ec6a24bba9197e12989de389e35b19c77a"
+checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.4"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek#e5a798697007891eb0ba3b8f452ca3ac8765aafc"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -275,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
+checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -288,8 +303,7 @@ dependencies = [
 [[package]]
 name = "dsa"
 version = "0.7.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f295219d1be8126f3767cefe40e01434224dede6f6337620622dc3294298322a"
+source = "git+https://github.com/RustCrypto/signatures#48b7f61e5221f38d4671e9701a28713e086c84ba"
 dependencies = [
  "crypto-bigint",
  "crypto-primes",
@@ -303,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.9"
+version = "0.17.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e914ecb8e11a02f42cc05f6b43675d1e5aa4d446cd207f9f818903a1ab34f19f"
+checksum = "6378f4db5c3e64d1c0bbde7948849ec7aaa231632a7c0ba1cfca7543e34ce9f5"
 dependencies = [
  "der",
  "digest",
@@ -326,9 +340,8 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d275a4ffdfc16e98fbcb5f5417214a06957c7cdc6eb2815c2dc50dce1c1dd"
+version = "3.0.0-pre.4"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek#e5a798697007891eb0ba3b8f452ca3ac8765aafc"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -338,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.17"
+version = "0.14.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
+checksum = "c8119dc256cd897f759f5b9d45dfd9b066af1c79e71688b7f0a6be989e8fbfbf"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -434,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbe8d6ac92e515ca2179ac331c1e4def09db2217d394683e73dace705c2f0c5"
+checksum = "627b64d2b280c7509b62060609926b1bbf8e5123b2b89dd99c6ee7a520d34260"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -447,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c729847b7cf17b9c96f9e6504400f64ae90cb1cdf23610cc1a51f18538ff95"
+checksum = "90a2f93da2b1f9714a97bf278158d5e832000c2929689c6ec538a9ec216c34f1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -461,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75296e7cb5d53c8a5083ff26b5707177962cd5851af961a56316e863f1ea757c"
+checksum = "503e2a38db6eb049ae116a31fef101c2445f5e3117ea9ff4d0be063be94910d4"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -534,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3ad342f52c70a953d95acb09a55450fdc07c2214283b81536c3f83f714568e"
+checksum = "9f4ec7ba23a4ad5298525e3208cdef746216a5a5a25614f5ea2c453dcc931092"
 dependencies = [
  "crypto-bigint",
  "rand_core",
@@ -547,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.1"
+version = "0.14.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e84a5f07d7a7c85f299e17753a98d8a09f10799894a637c9ce08d834b6ca02"
+checksum = "17a5fb1336715a650d236e3461954e69725d61251fcbd68a9656e7a764d53d09"
 dependencies = [
  "elliptic-curve",
 ]
@@ -574,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-2"
+version = "0.10.0-rc-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a23e4e8b77312a823b6b5613edbac78397e2f34320bc7ac4277013ec4478e"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "rfc6979"
@@ -591,8 +604,7 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.10.0-rc.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e499c52862d75a86c0024cc99dcb6d7127d15af3beae7b03573d62fab7ade08a"
+source = "git+https://github.com/RustCrypto/RSA#aa54cd9b021af284ec10b1307607260f9f516369"
 dependencies = [
  "const-oid",
  "crypto-bigint",
@@ -601,7 +613,6 @@ dependencies = [
  "rand_core",
  "sha2",
  "signature",
- "subtle",
  "zeroize",
 ]
 
@@ -717,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.5"
+version = "3.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
+checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
 dependencies = [
  "digest",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ ssh-cipher = { path = "./ssh-cipher" }
 ssh-derive = { path = "./ssh-derive" }
 ssh-encoding = { path = "./ssh-encoding" }
 ssh-key = { path = "./ssh-key" }
+
+crypto-primes = { git = "https://github.com/tarcieri/crypto-primes", branch = "crypto-bigint/v0.7.0-rc.13" }
+curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek" }
+dsa = { git = "https://github.com/RustCrypto/signatures" }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek" }
+rsa = { git = "https://github.com/RustCrypto/RSA" }

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -19,16 +19,16 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-cipher = "0.5.0-rc.1"
+cipher = "0.5.0-rc.3"
 encoding = { package = "ssh-encoding", version = "0.3.0-rc.2" }
 
 # optional dependencies
-aead = { version = "0.6.0-rc.3", optional = true, default-features = false }
+aead = { version = "0.6.0-rc.5", optional = true, default-features = false }
 aes = { version = "0.9.0-rc.2", optional = true, default-features = false }
 aes-gcm = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["aes"] }
 cbc = { version = "0.2.0-rc.2", optional = true }
 ctr = { version = "0.10.0-rc.2", optional = true, default-features = false }
-chacha20 = { version = "0.10.0-rc.5", optional = true, default-features = false, features = ["cipher", "legacy"] }
+chacha20 = { version = "0.10.0-rc.6", optional = true, default-features = false, features = ["cipher", "legacy"] }
 des = { version = "0.9.0-rc.2", optional = true, default-features = false }
 poly1305 = { version = "0.9.0-rc.3", optional = true, default-features = false }
 subtle = { version = "2", optional = true, default-features = false }

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -17,9 +17,9 @@ rust-version = "1.85"
 
 [dependencies]
 base64ct = { version = "1.8", optional = true }
-bigint = { package = "crypto-bigint", version = "0.7.0-rc.10", optional = true, default-features = false, features = ["alloc"] }
+bigint = { package = "crypto-bigint", version = "0.7.0-rc.13", optional = true, default-features = false, features = ["alloc"] }
 bytes = { version = "1", optional = true, default-features = false }
-digest = { version = "0.11.0-rc.4", optional = true, default-features = false }
+digest = { version = "0.11.0-rc.5", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true }
 ssh-derive = { version = "0.3.0-rc.0", optional = true }
 subtle = { version = "2", optional = true, default-features = false }

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -29,13 +29,13 @@ zeroize = { version = "1", default-features = false }
 argon2 = { version = "0.6.0-rc.5", optional = true, default-features = false, features = ["alloc"] }
 bcrypt-pbkdf = { version = "0.11.0-rc.2", optional = true, default-features = false, features = ["alloc"] }
 dsa = { version = "0.7.0-rc.7", optional = true, default-features = false, features = ["hazmat"] }
-ed25519-dalek = { version = "=3.0.0-pre.3", optional = true, default-features = false }
+ed25519-dalek = { version = "=3.0.0-pre.4", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 hmac = { version = "0.13.0-rc.3", optional = true }
-p256 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["ecdsa"] }
-p521 = { version = "0.14.0-rc.1", optional = true, default-features = false, features = ["ecdsa"] }
-rand_core = { version = "0.10.0-rc-2", optional = true, default-features = false }
+p256 = { version = "0.14.0-rc.2", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.14.0-rc.2", optional = true, default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.14.0-rc.2", optional = true, default-features = false, features = ["ecdsa"] }
+rand_core = { version = "0.10.0-rc-3", optional = true, default-features = false }
 rsa = { version = "0.10.0-rc.10", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.8.0-rc.10", optional = true, default-features = false, features = ["point"] }
 serde = { version = "1.0.16", optional = true }
@@ -43,7 +43,7 @@ sha1 = { version = "0.11.0-rc.3", optional = true, default-features = false, fea
 
 [dev-dependencies]
 hex-literal = "1"
-chacha20 = { version = "0.10.0-rc.5", features = ["rng"] }
+chacha20 = { version = "0.10.0-rc.6", features = ["rng"] }
 
 [features]
 default = ["ecdsa", "rand_core", "std"]


### PR DESCRIPTION
The following are some notable updates:
- `crypto-bigint` v0.7.0-rc.13 (migrates from `subtle` to `ctutils`)
- `rand_core` v0.10.0-rc-3