### PR TITLE
chore(deps): bump dependencies to latest pre-releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bcrypt-pbkdf"
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d28ed5f5f65056148fd25e1a596b5b6d9e772270abf9a9085d7cbfbf26c563"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
  "hybrid-array",
 ]
@@ -178,9 +178,9 @@ checksum = "c11ed919bd3bae4af5ab56372b627dfc32622aba6cec36906e8ab46746037c9d"
 
 [[package]]
 name = "const-oid"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.13"
+version = "0.7.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bb4138de6db76c8155b4423e967049fbef2cf84ad6af7f552f73a161941b72"
+checksum = "1a9e36ac79ac44866b74e08a0b4925f97b984e3fff17680d2c6fbce8317ab0f6"
 dependencies = [
  "ctutils",
  "hybrid-array",
@@ -208,11 +208,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6165b8029cdc3e765b74d3548f85999ee799d5124877ce45c2c85ca78e4d4aa"
+checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
 dependencies = [
  "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
@@ -320,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.10"
+version = "0.17.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6378f4db5c3e64d1c0bbde7948849ec7aaa231632a7c0ba1cfca7543e34ce9f5"
+checksum = "a18ccb2afbad0782e073b602a7d59dd08966d2b1173e08f96ebffb5446f8446d"
 dependencies = [
  "der",
  "digest",
@@ -355,12 +356,13 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.18"
+version = "0.14.0-rc.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8119dc256cd897f759f5b9d45dfd9b066af1c79e71688b7f0a6be989e8fbfbf"
+checksum = "6ee4530cd12af66979d89bf0e555c66d04ed1dc58479d7a69d93c98a650fb738"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "crypto-common",
  "digest",
  "hybrid-array",
  "rand_core",
@@ -420,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
  "hybrid-array",
@@ -451,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.2"
+version = "0.14.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627b64d2b280c7509b62060609926b1bbf8e5123b2b89dd99c6ee7a520d34260"
+checksum = "dcb1056e093c065babf1e9b0e28a630bee540cd9f5b905230ddc475175f5e9c8"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -464,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.2"
+version = "0.14.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a2f93da2b1f9714a97bf278158d5e832000c2929689c6ec538a9ec216c34f1"
+checksum = "69c56497d041697837a24928437cd1e7e7a7e7705037b0816f94550272e16a8e"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -478,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.2"
+version = "0.14.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503e2a38db6eb049ae116a31fef101c2445f5e3117ea9ff4d0be063be94910d4"
+checksum = "4383085fff29639c8d8d65e569e3ca58bee723358bd80bb3fb7492d519570989"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -492,18 +494,18 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383d290055c99f2dd7dece082088d89494dff6d79277fbac4a7da21c1bf2ab6b"
+checksum = "c351143b5ab27b1f1d24712f21ea4d0458fe74f60dd5839297dabcc2ecd24d58"
 dependencies = [
  "phc",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.2"
+version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4c07efb9394d8d0057793c35483868c2b8102e287e9d2d4328da0da36bcb4d"
+checksum = "c015873c38594dfb7724f90b2ed912a606697393bda2d39fd83c2394301f808a"
 dependencies = [
  "digest",
 ]
@@ -519,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f960577aaac5c259bc0866d685ba315c0ed30793c602d7287f54980913863"
+checksum = "71d390c5fe8d102c2c18ff39f1e72b9ad5996de282c2d831b0312f56910f5508"
 dependencies = [
  "base64ct",
  "subtle",
@@ -551,11 +553,12 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.2"
+version = "0.14.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4ec7ba23a4ad5298525e3208cdef746216a5a5a25614f5ea2c453dcc931092"
+checksum = "bf1f23afb6185c65efc97605dea2d667f6fef71cb9d3198992c1e9002e349f40"
 dependencies = [
  "crypto-bigint",
+ "crypto-common",
  "rand_core",
  "rustcrypto-ff",
  "subtle",
@@ -564,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.2"
+version = "0.14.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a5fb1336715a650d236e3461954e69725d61251fcbd68a9656e7a764d53d09"
+checksum = "12459f4bdd430002b812017c3e99f5a27a2c2689f1b140cb82a73c23431b71e0"
 dependencies = [
  "elliptic-curve",
 ]
@@ -653,11 +656,12 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.10"
+version = "0.8.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dff52f6118bc9f0ac974a54a639d499ac26a6cad7a6e39bc0990c19625e793b"
+checksum = "2568531a8ace88b848310caa98fb2115b151ef924d54aa523e659c21b9d32d71"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
  "hybrid-array",
  "subtle",
@@ -701,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
 dependencies = [
  "base16ct",
  "serde",
@@ -852,9 +856,9 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "universal-hash"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad6682ddb0189a4d3c2a5c54b8920ab6231ae911db53fc61a0709507bf1713b"
+checksum = "0386f227888b17b65d3e38219a7d41185035471300855c285667811907bb1677"
 dependencies = [
  "crypto-common",
  "subtle",

--- a/ssh-key/src/private/ecdsa.rs
+++ b/ssh-key/src/private/ecdsa.rs
@@ -10,6 +10,12 @@ use zeroize::Zeroize;
 #[cfg(feature = "rand_core")]
 use rand_core::CryptoRng;
 
+#[cfg(all(
+    feature = "rand_core",
+    any(feature = "p256", feature = "p384", feature = "p521")
+))]
+use cipher::cipher::crypto_common::Generate;
+
 /// Elliptic Curve Digital Signature Algorithm (ECDSA) private key.
 #[derive(Clone)]
 pub struct EcdsaPrivateKey<const SIZE: usize> {
@@ -211,7 +217,7 @@ impl EcdsaKeypair {
         match curve {
             #[cfg(feature = "p256")]
             EcdsaCurve::NistP256 => {
-                let Ok(private) = p256::SecretKey::try_from_rng(rng);
+                let private = p256::SecretKey::generate_from_rng(rng);
                 let public = private.public_key();
                 Ok(EcdsaKeypair::NistP256 {
                     private: private.into(),
@@ -220,7 +226,7 @@ impl EcdsaKeypair {
             }
             #[cfg(feature = "p384")]
             EcdsaCurve::NistP384 => {
-                let Ok(private) = p384::SecretKey::try_from_rng(rng);
+                let private = p384::SecretKey::generate_from_rng(rng);
                 let public = private.public_key();
                 Ok(EcdsaKeypair::NistP384 {
                     private: private.into(),
@@ -229,7 +235,7 @@ impl EcdsaKeypair {
             }
             #[cfg(feature = "p521")]
             EcdsaCurve::NistP521 => {
-                let Ok(private) = p521::SecretKey::try_from_rng(rng);
+                let private = p521::SecretKey::generate_from_rng(rng);
                 let public = private.public_key();
                 Ok(EcdsaKeypair::NistP521 {
                     private: private.into(),


### PR DESCRIPTION
```
    Updating base16ct v0.3.0 -> v1.0.0
    Updating base64ct v1.8.1 -> v1.8.2
    Updating block-padding v0.4.1 -> v0.4.2
   Unchanged bytes v1.10.1 (available: v1.11.0)
   Unchanged cfg-if v1.0.3 (available: v1.0.4)
    Updating const-oid v0.10.1 -> v0.10.2
    Updating crypto-bigint v0.7.0-rc.13 -> v0.7.0-rc.15
    Updating crypto-common v0.2.0-rc.8 -> v0.2.0-rc.9
    Updating ecdsa v0.17.0-rc.10 -> v0.17.0-rc.12
    Updating elliptic-curve v0.14.0-rc.18 -> v0.14.0-rc.21
    Updating inout v0.2.1 -> v0.2.2
   Unchanged libc v0.2.175 (available: v0.2.180)
    Updating p256 v0.14.0-rc.2 -> v0.14.0-rc.4
    Updating p384 v0.14.0-rc.2 -> v0.14.0-rc.4
    Updating p521 v0.14.0-rc.2 -> v0.14.0-rc.4
    Updating password-hash v0.6.0-rc.6 -> v0.6.0-rc.7
    Updating pbkdf2 v0.13.0-rc.2 -> v0.13.0-rc.5
    Updating phc v0.6.0-rc.0 -> v0.6.0-rc.1
    Updating primefield v0.14.0-rc.2 -> v0.14.0-rc.4
    Updating primeorder v0.14.0-rc.2 -> v0.14.0-rc.4
   Unchanged proc-macro2 v1.0.101 (available: v1.0.105)
   Unchanged quote v1.0.40 (available: v1.0.43)
    Updating sec1 v0.8.0-rc.10 -> v0.8.0-rc.11
   Unchanged semver v1.0.26 (available: v1.0.27)
   Unchanged serde v1.0.221 (available: v1.0.228)
   Unchanged serde_core v1.0.221 (available: v1.0.228)
   Unchanged serde_derive v1.0.221 (available: v1.0.228)
    Updating serdect v0.4.1 -> v0.4.2
   Unchanged syn v2.0.106 (available: v2.0.114)
   Unchanged typenum v1.18.0 (available: v1.19.0)
   Unchanged unicode-ident v1.0.19 (available: v1.0.22)
    Updating universal-hash v0.6.0-rc.3 -> v0.6.0-rc.4
```