### PR TITLE
ssh-key: bump `bcrypt-pbkdf` dependency to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.11.0-rc.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd80936d4a1ae6919e782d45e4ccb5928bf6d742d588ab8350b1417addcd325"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
 dependencies = [
  "blowfish",
  "pbkdf2",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.13.0-rc.10"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest",
 ]

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -37,7 +37,7 @@ zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 argon2 = { version = "0.6.0-rc.8", optional = true, default-features = false, features = ["alloc"] }
-bcrypt-pbkdf = { version = "0.11.0-rc.6", optional = true, default-features = false, features = ["alloc"] }
+bcrypt-pbkdf = { version = "0.11", optional = true, default-features = false, features = ["alloc"] }
 dsa = { version = "0.7.0-rc.14", optional = true, default-features = false, features = ["hazmat"] }
 ed25519-dalek = { version = "=3.0.0-pre.6", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Release PR: RustCrypto/password-hashes#889