### PR TITLE
ssh-key: bump `signature` crate dependency to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest",
  "rand_core",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -31,7 +31,7 @@ features = ["base64", "digest", "pem", "subtle", "zeroize"]
 
 [dependencies]
 sha2 = { version = "0.11", default-features = false }
-signature = { version = "3.0.0-rc.10", default-features = false }
+signature = { version = "3", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 


### PR DESCRIPTION
Release PR: RustCrypto/traits#2400