### PR TITLE
ssh-key: bump `ed25519-dalek` to v3.0.0-pre.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
 dependencies = [
  "curve25519-dalek",
  "ed25519",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -39,7 +39,7 @@ zeroize = { version = "1", default-features = false }
 argon2 = { version = "0.6.0-rc.8", optional = true, default-features = false, features = ["alloc"] }
 bcrypt-pbkdf = { version = "0.11", optional = true, default-features = false, features = ["alloc"] }
 dsa = { version = "0.7.0-rc.14", optional = true, default-features = false, features = ["hazmat"] }
-ed25519-dalek = { version = "=3.0.0-pre.6", optional = true, default-features = false }
+ed25519-dalek = { version = "3.0.0-pre.7", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 hmac = { version = "0.13.0-rc.5", optional = true }
 p256 = { version = "0.14.0-rc.9", optional = true, default-features = false, features = ["ecdsa"] }


### PR DESCRIPTION
Also loosens the `=` restriction since this crate is prctically finished