### PR TITLE
ssh-derive: configure and apply workspace-level lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-consts = true
+allow-unwrap-in-tests = true

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92 # pinned to prevent breakages when new rust versions are released
+          toolchain: 1.95 # pinned to prevent breakages when new rust versions are released
           components: clippy
-      - run: cargo clippy --all-features
+      - run: cargo clippy --all-features --all-targets
 
   doc:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - run: cargo doc --workspace --all-features
+      - run: cargo doc --workspace --all-features --no-deps
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,53 @@ members = [
     "ssh-protocol",
 ]
 
-[profile.dev]
-opt-level = 2
-
 [patch.crates-io]
 ssh-cipher = { path = "./ssh-cipher" }
 ssh-derive = { path = "./ssh-derive" }
 ssh-encoding = { path = "./ssh-encoding" }
 ssh-key = { path = "./ssh-key" }
+
+[profile.dev]
+opt-level = 2
+
+[workspace.lints.clippy]
+as_conversions = "warn"
+borrow_as_ptr = "warn"
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_precision_loss = "warn"
+cast_sign_loss = "warn"
+checked_conversions = "warn"
+from_iter_instead_of_collect = "warn"
+implicit_saturating_sub = "warn"
+integer_division_remainder_used = "warn"
+manual_assert = "warn"
+map_unwrap_or = "warn"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+mod_module_files = "warn"
+must_use_candidate = "warn"
+needless_range_loop = "allow"
+ptr_as_ptr = "warn"
+redundant_closure_for_method_calls = "warn"
+ref_as_ptr = "warn"
+return_self_not_must_use = "warn"
+semicolon_if_nothing_returned = "warn"
+trivially_copy_pass_by_ref = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
+undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unwrap_used = "warn"
+
+[workspace.lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unreachable_pub = "warn"
+unsafe_code = "forbid"
+unused_lifetimes = "warn"
+unused_qualifications = "warn"

--- a/ssh-cipher/src/chacha20poly1305.rs
+++ b/ssh-cipher/src/chacha20poly1305.rs
@@ -166,7 +166,6 @@ fn compute_mac(mut mac: Poly1305, aad: &[u8], buffer: &[u8]) -> Result<Tag> {
 #[cfg(test)]
 mod tests {
     use super::{AeadInOut, ChaCha20Poly1305, KeyInit, Poly1305, compute_mac};
-    use aead::array::AsArrayRef;
     use hex_literal::hex;
 
     #[test]
@@ -179,10 +178,10 @@ mod tests {
         const CT: [u8; 24] = hex!("6dcfb03be8a55e7f0220465672edd921489ea0171198e8a7");
         const TAG: [u8; 16] = hex!("3e82fe0a2db7128d58ef8d9047963ca3");
 
-        let cipher = ChaCha20Poly1305::new(KEY.as_array_ref());
-        let mut buffer = PT.clone();
+        let cipher = ChaCha20Poly1305::new(&KEY.into());
+        let mut buffer = PT;
         let actual_tag = cipher
-            .encrypt_inout_detached(NONCE.as_array_ref(), &AAD, buffer.as_mut_slice().into())
+            .encrypt_inout_detached(&NONCE.into(), &AAD, buffer.as_mut_slice().into())
             .unwrap();
 
         assert_eq!(buffer, CT);
@@ -190,7 +189,7 @@ mod tests {
 
         cipher
             .decrypt_inout_detached(
-                NONCE.as_array_ref(),
+                &NONCE.into(),
                 &AAD,
                 buffer.as_mut_slice().into(),
                 &actual_tag,
@@ -216,7 +215,7 @@ mod tests {
                 buffer[..aad_len].copy_from_slice(aad);
                 buffer[aad_len..eob].copy_from_slice(pt);
 
-                let poly = Poly1305::new(KEY.as_array_ref());
+                let poly = Poly1305::new(KEY.into());
                 let expected_mac = poly.clone().compute_unpadded(&buffer[..eob]);
                 let actual_mac = compute_mac(poly, aad, pt).unwrap();
 

--- a/ssh-derive/Cargo.toml
+++ b/ssh-derive/Cargo.toml
@@ -12,10 +12,13 @@ readme = "README.md"
 edition = "2024"
 rust-version = "1.85"
 
-[lib]
-proc-macro = true
-
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits"] }
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true

--- a/ssh-derive/src/encode.rs
+++ b/ssh-derive/src/encode.rs
@@ -222,8 +222,8 @@ fn fields_variables(fields: &syn::Fields, use_self: bool) -> Vec<TokenStream> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use super::*;
+    use core::iter;
     use proc_macro2::Span;
     use quote::quote;
 
@@ -322,7 +322,7 @@ mod tests {
             discriminant_type: None,
             length_prefixed: false,
         };
-        let err = derive_for_variants(&container_attributes, std::iter::once(&variant), &enum_name)
+        let err = derive_for_variants(&container_attributes, iter::once(&variant), &enum_name)
             .unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -338,7 +338,7 @@ mod tests {
             discriminant_type: Some(quote! { u8 }),
             length_prefixed: false,
         };
-        let err = derive_for_variants(&container_attributes, std::iter::once(&variant), &enum_name)
+        let err = derive_for_variants(&container_attributes, iter::once(&variant), &enum_name)
             .unwrap_err();
         assert_eq!(
             err.to_string(),

--- a/ssh-derive/src/lib.rs
+++ b/ssh-derive/src/lib.rs
@@ -1,3 +1,4 @@
+#![crate_type = "proc-macro"]
 #![doc = include_str!("../README.md")]
 
 //! ## About
@@ -8,15 +9,6 @@
 //! macros from the toplevel.
 //!
 //! [`ssh-encoding`]: ../ssh-encoding
-
-#![crate_type = "proc-macro"]
-#![forbid(unsafe_code)]
-#![warn(
-    clippy::unwrap_used,
-    rust_2018_idioms,
-    trivial_casts,
-    unused_qualifications
-)]
 
 macro_rules! abort {
     ( $tokens:expr, $message:expr $(,)? ) => {

--- a/ssh-key/tests/private_key.rs
+++ b/ssh-key/tests/private_key.rs
@@ -9,7 +9,7 @@ use ssh_key::EcdsaCurve;
 #[cfg(feature = "alloc")]
 use ssh_key::LineEnding;
 
-#[cfg(all(feature = "std"))]
+#[cfg(feature = "std")]
 use {
     ssh_key::PublicKey,
     std::{io, path::PathBuf, process},
@@ -685,7 +685,7 @@ fn round_trip_test(private_key: &str) -> PrivateKey {
 }
 
 /// Parse PEM encoded using `PrivateKey::to_openssh` using the `ssh-keygen` utility.
-#[cfg(all(feature = "std"))]
+#[cfg(feature = "std")]
 fn encoding_integration_test(private_key: PrivateKey) {
     let fingerprint = private_key
         .fingerprint(Default::default())

--- a/ssh-key/tests/public_key.rs
+++ b/ssh-key/tests/public_key.rs
@@ -359,7 +359,7 @@ fn new_sk_ed25519_openssh() {
     assert_eq!(&sk_key, ed25519_key);
 }
 
-#[cfg(all(feature = "alloc"))]
+#[cfg(feature = "alloc")]
 #[test]
 fn decode_custom_algorithm_openssh() {
     let key = PublicKey::from_openssh(OPENSSH_OPAQUE_EXAMPLE).unwrap();


### PR DESCRIPTION
Adds the workspace-level config from RustCrypto/utils#1411 to this repo and applies it to `ssh-derive`.