### PR TITLE
ssh-derive v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-derive"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ssh-derive/CHANGELOG.md
+++ b/ssh-derive/CHANGELOG.md
@@ -3,3 +3,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2026-05-10)
+Initial release. Earlier versions skipped to match v0.3 release of `ssh-cipher`/`ssh-encoding`.

--- a/ssh-derive/Cargo.toml
+++ b/ssh-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-derive"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 description = "Custom derive support for the `ssh-encoding` crate"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/ssh-derive/README.md
+++ b/ssh-derive/README.md
@@ -13,13 +13,6 @@
 
 Custom derive support for the `Decode` and `Encode` traits in the [`ssh-encoding`] crate.
 
-## Minimum Supported Rust Version
-
-This crate requires **Rust 1.85** at a minimum.
-
-We may change the MSRV in the future, but it will be accompanied by a minor
-version bump.
-
 ## License
 
 Licensed under either of:

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -22,7 +22,7 @@ bytes = { version = "1", optional = true, default-features = false }
 ctutils = { version = "0.4", optional = true, default-features = false }
 digest = { version = "0.11", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true }
-ssh-derive = { version = "0.3.0-rc.0", optional = true }
+ssh-derive = { version = "0.3", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Initial release. Earlier versions skipped to match v0.3 release of `ssh-cipher`/`ssh-encoding`.