### PR TITLE
ssh-encoding: ensure vulnerable versions of `bytes` are not used

### DIFF
--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.85"
 [dependencies]
 base64ct = { version = "1.8", optional = true }
 bigint = { package = "crypto-bigint", version = "0.7", optional = true, default-features = false, features = ["alloc"] }
-bytes = { version = "1", optional = true, default-features = false }
+bytes = { version = "1.11", optional = true, default-features = false }
 ctutils = { version = "0.4", optional = true, default-features = false }
 digest = { version = "0.11", optional = true, default-features = false }
 pem-rfc7468 = { version = "1", optional = true }


### PR DESCRIPTION
See RUSTSEC-2026-0007