### PR TITLE
ssh-encoding: add `diagnostic::on_unimplemented` hints

### DIFF
--- a/ssh-encoding/src/checked.rs
+++ b/ssh-encoding/src/checked.rs
@@ -3,6 +3,9 @@
 use crate::{Error, Result};
 
 /// Extension trait for providing checked [`Iterator::sum`]-like functionality.
+#[diagnostic::on_unimplemented(
+    note = "Consider adding an impl of `IntoIterator<Item = usize>` to `{Self}`"
+)]
 pub trait CheckedSum<A>: Sized {
     /// Iterate over the values of this type, computing a checked sum.
     ///

--- a/ssh-encoding/src/pem/decode.rs
+++ b/ssh-encoding/src/pem/decode.rs
@@ -3,8 +3,11 @@ use crate::{Decode, Error, Reader};
 
 /// Decoding trait for PEM documents.
 ///
-/// This is an extension trait which is auto-impl'd for types which impl the
-/// [`Decode`], [`PemLabel`], and [`Sized`] traits.
+/// This is an extension trait which is auto-impl'd for types which impl the [`Decode`],
+/// [`PemLabel`], and [`Sized`] traits.
+#[diagnostic::on_unimplemented(
+    note = "Consider adding impls of `Decode` and `PemLabel` to `{Self}`"
+)]
 pub trait DecodePem: Decode + PemLabel + Sized {
     /// Decode the provided PEM-encoded string, interpreting the Base64-encoded body of the document
     /// using the [`Decode`] trait.

--- a/ssh-encoding/src/pem/encode.rs
+++ b/ssh-encoding/src/pem/encode.rs
@@ -9,6 +9,9 @@ use {super::LINE_WIDTH, alloc::string::String};
 ///
 /// This is an extension trait which is auto-impl'd for types which impl the [`Encode`] and
 /// [`PemLabel`] traits.
+#[diagnostic::on_unimplemented(
+    note = "Consider adding impls of `Encode` and `PemLabel` to `{Self}`"
+)]
 pub trait EncodePem: Encode + PemLabel {
     /// Encode this type using the [`Encode`] trait, writing the resulting PEM document into the
     /// provided `out` buffer.


### PR DESCRIPTION
These add some notes for figuring out how/when to use the blanket impls for `PemDecode`, `PemEncode`, and `CheckedSum`