### PR TITLE
ssh-cipher: update dependency requirements in `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.9.0-rc.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19feddcbdf17fad33f40041c7f9e768faf19455f32a6d52ba1b8b65ffc7b1cae"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
 dependencies = [
  "cpufeatures 0.3.0",
  "universal-hash",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -24,14 +24,14 @@ encoding = { package = "ssh-encoding", version = "0.3.0-rc.9" }
 
 # optional dependencies
 aead = { version = "0.6.0-rc.10", optional = true, default-features = false }
-aes = { version = "0.9.0-rc.4", optional = true, default-features = false }
+aes = { version = "0.9", optional = true, default-features = false }
 aes-gcm = { version = "0.11.0-rc.3", optional = true, default-features = false, features = ["aes"] }
 cbc = { version = "0.2", optional = true }
-ctr = { version = "0.10.0-rc.4", optional = true, default-features = false }
+ctr = { version = "0.10", optional = true, default-features = false }
 ctutils = { version = "0.4", optional = true, default-features = false }
-chacha20 = { version = "0.10.0-rc.10", optional = true, default-features = false, features = ["cipher", "legacy"] }
-des = { version = "0.9.0-rc.3", optional = true, default-features = false }
-poly1305 = { version = "0.9.0-rc.6", optional = true, default-features = false }
+chacha20 = { version = "0.10", optional = true, default-features = false, features = ["cipher", "legacy"] }
+des = { version = "0.9", optional = true, default-features = false }
+poly1305 = { version = "0.9", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Updates the following dependency requirements:
- `aes` v0.9
- `ctr` v0.10
- `chacha20` v0.10
- `des` v0.9
- `poly1305` v0.9