### PR TITLE
ssh-key: bump `hmac` dependency to v0.13

### DIFF
--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -41,7 +41,7 @@ bcrypt-pbkdf = { version = "0.11", optional = true, default-features = false, fe
 dsa = { version = "0.7.0-rc.14", optional = true, default-features = false, features = ["hazmat"] }
 ed25519-dalek = { version = "3.0.0-pre.7", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
-hmac = { version = "0.13.0-rc.5", optional = true }
+hmac = { version = "0.13", optional = true }
 p256 = { version = "0.14.0-rc.9", optional = true, default-features = false, features = ["ecdsa"] }
 p384 = { version = "0.14.0-rc.9", optional = true, default-features = false, features = ["ecdsa"] }
 p521 = { version = "0.14.0-rc.9", optional = true, default-features = false, features = ["ecdsa"] }


### PR DESCRIPTION
Release PR: RustCrypto/MACs#263