### PR TITLE
CI: add `lock` and `typos` check

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -14,6 +14,11 @@ env:
   RUSTFLAGS: "-Dwarnings"
   RUSTDOCFLAGS: "-Dwarnings"
 
+# Cancels CI jobs when new commits are pushed to a PR branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   clippy:
     runs-on: ubuntu-latest
@@ -35,6 +40,13 @@ jobs:
           toolchain: stable
       - run: cargo doc --workspace --all-features --no-deps
 
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check --workspace --locked
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:
@@ -44,3 +56,9 @@ jobs:
           toolchain: stable
           components: rustfmt
       - run: cargo fmt --all -- --check
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.46.0

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,16 @@
+[files]
+extend-exclude = [
+    ".git/",
+]
+
+[default]
+extend-ignore-re = [
+    # Patterns which appear to be 36 or more characters of Base64/Base64url
+    '\b[0-9A-Za-z+/]{36,}\b',
+    '\b[0-9A-Za-z_-]{36,}\b',
+]
+
+[default.extend-words]
+consts = "consts"
+"Ede" = "Ede" # Encrypt-Decrypt-Encrypt
+"nameß" = "nameß" # Invalid name example

--- a/ssh-encoding/src/encode.rs
+++ b/ssh-encoding/src/encode.rs
@@ -242,9 +242,9 @@ impl_by_delegation!(
     impl Encode for Bytes where self -> self.as_ref();
 
     // While deref coercion ensures that `&E` can use the `Encode` trait methods, it will not be
-    // allowd in trait bounds, as `&E` does not implement `Encode` itself just because `E: Encode`.
+    // allowed in trait bounds, as `&E` does not implement `Encode` itself just because `E: Encode`.
     // A blanket impl for `&E` would be the most generic, but that collides with the `Label` trait's
-    // blanket impl. Instead, we can do it explicitly for the immediatley relevant base types.
+    // blanket impl. Instead, we can do it explicitly for the immediately relevant base types.
     impl Encode for &str where self -> **self;
     impl Encode for &[u8] where self -> **self;
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
Ensures `Cargo.lock` is up-to-date, and checks for typos