### PR TITLE
ssh-cipher: impl `BlockMode*` for `Decryptor`/`Encryptor`

### DIFF
--- a/ssh-cipher/src/block_cipher.rs
+++ b/ssh-cipher/src/block_cipher.rs
@@ -9,19 +9,20 @@ mod decryptor;
 mod encryptor;
 mod state;
 
+pub use self::{decryptor::Decryptor, encryptor::Encryptor};
+pub use ::cipher::{
+    Block, BlockModeDecrypt, BlockModeEncrypt, common::BlockSizeUser, common::InvalidLength,
+};
+
 #[cfg(feature = "aes")]
 pub use self::aes::Aes;
-pub use self::{decryptor::Decryptor, encryptor::Encryptor};
 #[cfg(feature = "tdes")]
 pub use ::des::TdesEde3 as Tdes;
 
 use self::state::State;
 
 #[cfg(feature = "tdes")]
-use {
-    crate::Cipher,
-    ::cipher::common::{InvalidLength, KeyInit},
-};
+use {crate::Cipher, ::cipher::common::KeyInit};
 
 /// Seal the `BlockCipher` trait so others cannot implement it.
 pub(crate) mod sealed {

--- a/ssh-cipher/src/block_cipher/decryptor.rs
+++ b/ssh-cipher/src/block_cipher/decryptor.rs
@@ -2,7 +2,10 @@
 
 use super::{BlockMode, State, sealed::BlockCipher};
 use crate::{Cipher, Error, Result};
-use ::cipher::{Block, typenum::Unsigned};
+use ::cipher::{
+    Block, BlockModeDecClosure, BlockModeDecrypt,
+    common::{BlockSizeUser, InnerUser},
+};
 use core::fmt::{self, Debug};
 
 /// Stateful decryptor object for unauthenticated symmetric ciphers used in the SSH packet
@@ -38,24 +41,6 @@ impl<C: BlockCipher> Decryptor<C> {
         Ok(Self { cipher, state })
     }
 
-    /// Decrypt the given buffer in place.
-    ///
-    /// # Errors
-    /// Returns [`Error::Length`] in the event that `buffer` is not a multiple of the cipher's
-    /// block size.
-    pub fn decrypt(&mut self, buffer: &mut [u8]) -> Result<()> {
-        #[allow(clippy::integer_division_remainder_used, reason = "non-secret length")]
-        if buffer.len() % C::BlockSize::USIZE != 0 {
-            return Err(Error::Length);
-        }
-
-        for block in Block::<C>::slice_as_chunks_mut(buffer).0 {
-            self.decrypt_block(block);
-        }
-
-        Ok(())
-    }
-
     /// Call the provided function with an ephemeral [`Decryptor`] state which will be reset upon
     /// completion, returning the result of the function.
     pub fn peek<T, F>(&mut self, mut f: F) -> T
@@ -67,12 +52,14 @@ impl<C: BlockCipher> Decryptor<C> {
         self.state = state;
         ret
     }
+}
 
-    /// Decrypt a single block.
-    ///
-    /// # Panics
-    /// If `block` is not the correct block size for this cipher.
-    fn decrypt_block(&mut self, block: &mut Block<C>) {
+impl<C: BlockCipher> BlockModeDecrypt for Decryptor<C> {
+    fn decrypt_with_backend(&mut self, _f: impl BlockModeDecClosure<BlockSize = Self::BlockSize>) {
+        unimplemented!("CTR mode support is incompatible with BlockModeDecrypt")
+    }
+
+    fn decrypt_block(&mut self, block: &mut Block<Self>) {
         match self.state.mode() {
             BlockMode::Cbc => {
                 let pad = self.state.clone();
@@ -88,10 +75,24 @@ impl<C: BlockCipher> Decryptor<C> {
             }
         }
     }
+
+    fn decrypt_blocks(&mut self, blocks: &mut [Block<Self>]) {
+        // TODO(tarcieri): parallel decryption support
+        for block in blocks {
+            self.decrypt_block(block);
+        }
+    }
+}
+impl<C: BlockCipher> BlockSizeUser for Decryptor<C> {
+    type BlockSize = C::BlockSize;
 }
 
 impl<C: BlockCipher> Debug for Decryptor<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Decryptor").finish_non_exhaustive()
     }
+}
+
+impl<C: BlockCipher> InnerUser for Decryptor<C> {
+    type Inner = C;
 }

--- a/ssh-cipher/src/block_cipher/encryptor.rs
+++ b/ssh-cipher/src/block_cipher/encryptor.rs
@@ -2,7 +2,15 @@
 
 use super::{BlockMode, State, sealed::BlockCipher};
 use crate::{Cipher, Error, Result};
-use ::cipher::{Block, typenum::Unsigned};
+use ::cipher::{
+    Block, BlockCipherEncBackend, BlockCipherEncClosure, BlockModeEncBackend, BlockModeEncClosure,
+    BlockModeEncrypt,
+    common::{
+        BlockSizeUser, InnerUser, ParBlocksSizeUser,
+        array::{ArraySize, sizes::U1},
+    },
+    inout::InOut,
+};
 use core::fmt::{self, Debug};
 
 /// Stateful encryptor object for unauthenticated symmetric ciphers used in the SSH packet
@@ -34,48 +42,114 @@ impl<C: BlockCipher> Encryptor<C> {
         let state = State::new_from_slice(mode, iv)?;
         Ok(Self { cipher, state })
     }
+}
 
-    /// Encrypt the given buffer in-place.
-    ///
-    /// # Errors
-    /// Returns [`Error::Length`] in the event that `buffer` is not a multiple of the cipher's
-    /// block size.
-    pub fn encrypt(&mut self, buffer: &mut [u8]) -> Result<()> {
-        #[allow(clippy::integer_division_remainder_used, reason = "non-secret length")]
-        if buffer.len() % C::BlockSize::USIZE != 0 {
-            return Err(Error::Length);
+impl<C: BlockCipher> BlockModeEncrypt for Encryptor<C> {
+    fn encrypt_with_backend(&mut self, f: impl BlockModeEncClosure<BlockSize = Self::BlockSize>) {
+        struct Closure<'a, BS, BC>
+        where
+            BS: ArraySize,
+            BC: BlockModeEncClosure<BlockSize = BS>,
+        {
+            state: &'a mut State<BS>,
+            f: BC,
         }
 
-        for block in Block::<C>::slice_as_chunks_mut(buffer).0 {
-            self.encrypt_block(block);
+        impl<BS, BC> BlockSizeUser for Closure<'_, BS, BC>
+        where
+            BS: ArraySize,
+            BC: BlockModeEncClosure<BlockSize = BS>,
+        {
+            type BlockSize = BS;
         }
 
-        Ok(())
-    }
-
-    /// Encrypt a single block.
-    ///
-    /// # Panics
-    /// If `block` is not the correct block size for this cipher.
-    fn encrypt_block(&mut self, block: &mut Block<C>) {
-        match self.state.mode() {
-            BlockMode::Cbc => {
-                self.state.xor_into(block);
-                self.cipher.encrypt_block(block);
-                self.state.as_mut().copy_from_slice(block);
+        impl<BS, BC> BlockCipherEncClosure for Closure<'_, BS, BC>
+        where
+            BS: ArraySize,
+            BC: BlockModeEncClosure<BlockSize = BS>,
+        {
+            #[inline(always)]
+            fn call<B: BlockCipherEncBackend<BlockSize = Self::BlockSize>>(
+                self,
+                cipher_backend: &B,
+            ) {
+                let Self { state, f } = self;
+                f.call(&mut Backend {
+                    state,
+                    cipher_backend,
+                });
             }
-            BlockMode::Ctr => {
-                let mut pad = self.state.clone();
-                self.cipher.encrypt_block(pad.as_mut());
-                pad.xor_into(block);
-                self.state.increment_counter();
-            }
         }
+
+        let Self { cipher, state } = self;
+        cipher.encrypt_with_backend(Closure { state, f });
     }
+}
+
+impl<C: BlockCipher> BlockSizeUser for Encryptor<C> {
+    type BlockSize = C::BlockSize;
 }
 
 impl<C: BlockCipher> Debug for Encryptor<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Encryptor").finish_non_exhaustive()
+    }
+}
+
+impl<C: BlockCipher> InnerUser for Encryptor<C> {
+    type Inner = C;
+}
+
+struct Backend<'a, BS, BK>
+where
+    BS: ArraySize,
+    BK: BlockCipherEncBackend<BlockSize = BS>,
+{
+    state: &'a mut State<BS>,
+    cipher_backend: &'a BK,
+}
+
+impl<BS, BK> BlockSizeUser for Backend<'_, BS, BK>
+where
+    BS: ArraySize,
+    BK: BlockCipherEncBackend<BlockSize = BS>,
+{
+    type BlockSize = BS;
+}
+
+impl<BS, BK> ParBlocksSizeUser for Backend<'_, BS, BK>
+where
+    BS: ArraySize,
+    BK: BlockCipherEncBackend<BlockSize = BS>,
+{
+    // CBC encryption cannot be performed in parallel
+    // TODO(tarcieri): parallel encryption support for CTR mode, serial for CBC
+    type ParBlocksSize = U1;
+}
+
+impl<BS, BK> BlockModeEncBackend for Backend<'_, BS, BK>
+where
+    BS: ArraySize,
+    BK: BlockCipherEncBackend<BlockSize = BS>,
+{
+    #[inline(always)]
+    fn encrypt_block(&mut self, mut block: InOut<'_, '_, Block<Self>>) {
+        let mut t = block.clone_in();
+
+        match self.state.mode() {
+            BlockMode::Cbc => {
+                self.state.xor_into(&mut t);
+                self.cipher_backend.encrypt_block(InOut::from(&mut t));
+                self.state.as_mut().copy_from_slice(&t);
+            }
+            BlockMode::Ctr => {
+                let mut pad = self.state.clone();
+                self.cipher_backend.encrypt_block(pad.as_mut().into());
+                pad.xor_into(&mut t);
+                self.state.increment_counter();
+            }
+        }
+
+        *block.get_out() = t;
     }
 }

--- a/ssh-cipher/src/lib.rs
+++ b/ssh-cipher/src/lib.rs
@@ -27,10 +27,13 @@ use encoding::{Label, LabelError};
 use self::block_cipher::Aes;
 #[cfg(feature = "tdes")]
 use self::block_cipher::Tdes;
-#[cfg(any(feature = "aes", feature = "tdes"))]
-use self::block_cipher::{BlockMode, sealed::BlockCipher};
 #[cfg(any(feature = "aes", feature = "chacha20poly1305"))]
 use ::aead::{AeadInOut, KeyInit};
+#[cfg(any(feature = "aes", feature = "tdes"))]
+use {
+    self::block_cipher::{BlockMode, sealed::BlockCipher},
+    ::cipher::{Block, BlockModeDecrypt, BlockModeEncrypt},
+};
 #[cfg(feature = "aes")]
 use {
     aead::array::typenum::U12,
@@ -302,8 +305,7 @@ impl Cipher {
                 if tag.is_some() {
                     return Err(Error::Crypto);
                 }
-
-                self.decryptor::<Aes>(key, iv)?.decrypt(buffer)
+                self.decrypt_with_block_cipher::<Aes>(key, iv, buffer)
             }
             #[cfg(feature = "tdes")]
             Self::TdesCbc => {
@@ -311,11 +313,33 @@ impl Cipher {
                 if tag.is_some() {
                     return Err(Error::Crypto);
                 }
-
-                self.decryptor::<Tdes>(key, iv)?.decrypt(buffer)
+                self.decrypt_with_block_cipher::<Tdes>(key, iv, buffer)
             }
             _ => Err(Error::UnsupportedCipher(self)),
         }
+    }
+
+    /// Perform decryption using a dynamically selected block cipher mode of operation.
+    ///
+    /// Note that this does not support any form of padding currently.
+    ///
+    /// # Errors
+    /// Returns [`Error::Length`] unless the length of `buffer` is a multiple of the block size.
+    #[cfg(any(feature = "aes", feature = "tdes"))]
+    fn decrypt_with_block_cipher<C: BlockCipher>(
+        self,
+        key: &[u8],
+        iv: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<()> {
+        let (blocks, remaining) = Block::<C>::slice_as_chunks_mut(buffer);
+
+        if !remaining.is_empty() {
+            return Err(Error::Length);
+        }
+
+        self.decryptor::<C>(key, iv)?.decrypt_blocks(blocks);
+        Ok(())
     }
 
     /// Get a stateful [`block_cipher::Decryptor`] for the given key and IV.
@@ -377,16 +401,39 @@ impl Cipher {
             | Self::Aes128Ctr
             | Self::Aes192Ctr
             | Self::Aes256Ctr => {
-                self.encryptor::<Aes>(key, iv)?.encrypt(buffer)?;
+                self.encrypt_with_block_cipher::<Aes>(key, iv, buffer)?;
                 Ok(None)
             }
             #[cfg(feature = "tdes")]
             Self::TdesCbc => {
-                self.encryptor::<Tdes>(key, iv)?.encrypt(buffer)?;
+                self.encrypt_with_block_cipher::<Tdes>(key, iv, buffer)?;
                 Ok(None)
             }
             _ => Err(Error::UnsupportedCipher(self)),
         }
+    }
+
+    /// Perform decryption using a dynamically selected block cipher mode of operation.
+    ///
+    /// Note that this does not support any form of padding currently.
+    ///
+    /// # Errors
+    /// Returns [`Error::Length`] unless the length of `buffer` is a multiple of the block size.
+    #[cfg(any(feature = "aes", feature = "tdes"))]
+    fn encrypt_with_block_cipher<C: BlockCipher>(
+        self,
+        key: &[u8],
+        iv: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<()> {
+        let (blocks, remaining) = Block::<C>::slice_as_chunks_mut(buffer);
+
+        if !remaining.is_empty() {
+            return Err(Error::Length);
+        }
+
+        self.encryptor::<C>(key, iv)?.encrypt_blocks(blocks);
+        Ok(())
     }
 
     /// Get a stateful [`block_cipher::Encryptor`] for the given key and IV.


### PR DESCRIPTION
Impls the `BlockMode*` traits from the `cipher` crate, bringing the implementation closer in line with our other block mode implementations.

This does have one weird quirk: we can't impl
`BlockModeDecrypt::decrypt_with_backend` for `Decryptor` because that only gives us access to `BlockCipherDecBackend`, whereas to implement CTR mode we need access to `BlockCipherEncBackend` too as encryption and decryption are the same operation in CTR mode.

So this foregoes such an impl with an `unimplemented!` and directly implements the `decrypt_block` and `decrypt_blocks` methods instead.