### PR TITLE
ssh-encoding v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-encoding"
-version = "0.3.0-rc.9"
+version = "0.3.0"
 dependencies = [
  "base64ct",
  "bytes",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.85"
 
 [dependencies]
 cipher = "0.5"
-encoding = { package = "ssh-encoding", version = "0.3.0-rc.9" }
+encoding = { package = "ssh-encoding", version = "0.3" }
 
 # optional dependencies
 aead = { version = "0.6.0-rc.10", optional = true, default-features = false }

--- a/ssh-encoding/CHANGELOG.md
+++ b/ssh-encoding/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2026-05-25)
+### Added
+- `boolean` encode/decode support ([#214])
+- `Base64Reader`/`Base64Writer` newtypes ([#220])
+- `base64` module ([#222])
+- PEM line width detection ([#252])
+- `Encode::{encode_vec, encode_bytes}` ([#267])
+- `DigestWriter` ([#268])
+- `digest` feature ([#271])
+- `core::error::Error` support ([#303])
+- Custom derive for `Encode`/`Decode` via `derive` feature ([#348])
+- Propagate `base64ct` errors ([#358])
+- `Mpint` type ([#359])
+- Implement `Encode` for string-like type sequences ([#377])
+- `diagnostic::on_unimplemented` hints ([#514])
+
+### Changed
+- `[u8; N]` no longer encodes a length prefix but treats `N` as statically known ([#342])
+- Upgrade to 2024 edition; MSRV 1.85 ([#354])
+- Bump `hex-literal` dependency to v1 ([#355])
+- Migrate from `subtle` to `ctutils` ([#507])
+
+### Removed
+- `NestedReader` ([#226])
+- `sha2` dependency - now generic around digests ([#271])
+- `std` feature ([#303])
+
+[#214]: https://github.com/RustCrypto/SSH/pull/214
+[#220]: https://github.com/RustCrypto/SSH/pull/220
+[#222]: https://github.com/RustCrypto/SSH/pull/222
+[#226]: https://github.com/RustCrypto/SSH/pull/226
+[#252]: https://github.com/RustCrypto/SSH/pull/252
+[#267]: https://github.com/RustCrypto/SSH/pull/267
+[#268]: https://github.com/RustCrypto/SSH/pull/268
+[#271]: https://github.com/RustCrypto/SSH/pull/271
+[#303]: https://github.com/RustCrypto/SSH/pull/303
+[#342]: https://github.com/RustCrypto/SSH/pull/342
+[#348]: https://github.com/RustCrypto/SSH/pull/348
+[#354]: https://github.com/RustCrypto/SSH/pull/354
+[#355]: https://github.com/RustCrypto/SSH/pull/355
+[#358]: https://github.com/RustCrypto/SSH/pull/358
+[#359]: https://github.com/RustCrypto/SSH/pull/359
+[#377]: https://github.com/RustCrypto/SSH/pull/377
+[#507]: https://github.com/RustCrypto/SSH/pull/507
+[#514]: https://github.com/RustCrypto/SSH/pull/514
+
 ## 0.2.0 (2023-08-11)
 ### Added
 - `LabelError` ([#124])

--- a/ssh-encoding/Cargo.toml
+++ b/ssh-encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-encoding"
-version = "0.3.0-rc.9"
+version = "0.3.0"
 description = "Pure Rust implementation of SSH data type decoders/encoders as described in RFC4251"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -25,7 +25,7 @@ features = ["zeroize"]
 
 # ssh-encoding
 [dependencies.encoding]
-version = "0.3.0-rc.9"
+version = "0.3"
 package = "ssh-encoding"
 features = ["base64", "digest", "pem", "ctutils", "zeroize"]
 

--- a/ssh-protocol/Cargo.toml
+++ b/ssh-protocol/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.85"
 
 [dependencies]
 cipher = { package = "ssh-cipher", version = "0.3.0-rc.9", default-features = false }
-encoding = { package = "ssh-encoding", version = "0.3.0-rc.9", default-features = false }
+encoding = { package = "ssh-encoding", version = "0.3", default-features = false }
 key = { package = "ssh-key", version = "0.7.0-rc.8", default-features = false }
 
 [features]


### PR DESCRIPTION
## Added
- `boolean` encode/decode support ([#214])
- `Base64Reader`/`Base64Writer` newtypes ([#220])
- `base64` module ([#222])
- PEM line width detection ([#252])
- `Encode::{encode_vec, encode_bytes}` ([#267])
- `DigestWriter` ([#268])
- `digest` feature ([#271])
- `core::error::Error` support ([#303])
- Custom derive for `Encode`/`Decode` via `derive` feature ([#348])
- Propagate `base64ct` errors ([#358])
- `Mpint` type ([#359])
- Implement `Encode` for string-like type sequences ([#377])
- `diagnostic::on_unimplemented` hints ([#514])

## Changed
- `[u8; N]` no longer encodes a length prefix but treats `N` as statically known ([#342])
- Upgrade to 2024 edition; MSRV 1.85 ([#354])
- Bump `hex-literal` dependency to v1 ([#355])
- Migrate from `subtle` to `ctutils` ([#507])

## Removed
- `NestedReader` ([#226])
- `sha2` dependency - now generic around digests ([#271])
- `std` feature ([#303])

[#214]: https://github.com/RustCrypto/SSH/pull/214
[#220]: https://github.com/RustCrypto/SSH/pull/220
[#222]: https://github.com/RustCrypto/SSH/pull/222
[#226]: https://github.com/RustCrypto/SSH/pull/226
[#252]: https://github.com/RustCrypto/SSH/pull/252
[#267]: https://github.com/RustCrypto/SSH/pull/267
[#268]: https://github.com/RustCrypto/SSH/pull/268
[#271]: https://github.com/RustCrypto/SSH/pull/271
[#303]: https://github.com/RustCrypto/SSH/pull/303
[#342]: https://github.com/RustCrypto/SSH/pull/342
[#348]: https://github.com/RustCrypto/SSH/pull/348
[#354]: https://github.com/RustCrypto/SSH/pull/354
[#355]: https://github.com/RustCrypto/SSH/pull/355
[#358]: https://github.com/RustCrypto/SSH/pull/358
[#359]: https://github.com/RustCrypto/SSH/pull/359
[#377]: https://github.com/RustCrypto/SSH/pull/377
[#507]: https://github.com/RustCrypto/SSH/pull/507
[#514]: https://github.com/RustCrypto/SSH/pull/514