### PR TITLE
ssh-cipher: bump `aead` to v0.6; `aes-gcm` to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.11.0-rc.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -22,9 +22,9 @@ cipher = "0.5"
 encoding = { package = "ssh-encoding", version = "0.3" }
 
 # optional dependencies
-aead = { version = "0.6.0-rc.10", optional = true, default-features = false }
+aead = { version = "0.6", optional = true, default-features = false }
 aes = { version = "0.9", optional = true, default-features = false }
-aes-gcm = { version = "0.11.0-rc.4", optional = true, default-features = false, features = ["aes"] }
+aes-gcm = { version = "0.11", optional = true, default-features = false, features = ["aes"] }
 ctutils = { version = "0.4", optional = true, default-features = false }
 chacha20 = { version = "0.10", optional = true, default-features = false, features = ["cipher", "legacy"] }
 des = { version = "0.9", optional = true, default-features = false }


### PR DESCRIPTION
Release PRs:
- `aead`: RustCrypto/traits#2466
- `aes-gcm`: RustCrypto/AEADs#852