### PR TITLE
ssh-cipher v0.3.0

### DIFF
--- a/.github/workflows/ssh-cipher.yml
+++ b/.github/workflows/ssh-cipher.yml
@@ -41,7 +41,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,std,getrandom
+      - run: cargo hack build --target ${{ matrix.target }} --feature-powerset --exclude-features default,getrandom
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-cipher"
-version = "0.3.0-rc.10"
+version = "0.3.0"
 dependencies = [
  "aead",
  "aes",

--- a/ssh-cipher/CHANGELOG.md
+++ b/ssh-cipher/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2026-06-28)
+### Added
+- `Decryptor` and `Encryptor` ([#253], [#533], [#534])
+- `ChaCha20Poly1305` implementing SSH-flavored construction with `aead` API ([#256], [#370])
+- `zeroize` feature ([#283])
+- `core::error::Error` support ([#303])
+- `getrandom` and `rand_core` feature passthroughs ([#535])
+- `encoding` feature ([#560])
+
+### Changed
+- Upgrade to 2024 edition; MSRV 1.85 ([#354])
+- Migrate from `subtle` to `ctutils` ([#507])
+- Consolidate `aes` feature instead of per-block-mode features ([#530])
+- Upgrade low-level symmetric crypto dependencies ([#516])
+  - `aes` v0.9
+  - `ctr` v0.10
+  - `chacha20` v0.10
+  - `des` v0.9
+  - `poly1305` v0.9
+- Upgrade `ssh-encoding` to v0.3 ([#537])
+- Upgrade AEAD dependencies ([#557])
+  - `aead` 0.6
+  - `aes-gcm` v0.11
+
+### Removed
+- `std` feature ([#303])
+
+[#253]: https://github.com/RustCrypto/SSH/pull/253
+[#256]: https://github.com/RustCrypto/SSH/pull/256
+[#283]: https://github.com/RustCrypto/SSH/pull/283
+[#303]: https://github.com/RustCrypto/SSH/pull/303
+[#354]: https://github.com/RustCrypto/SSH/pull/354
+[#370]: https://github.com/RustCrypto/SSH/pull/370
+[#507]: https://github.com/RustCrypto/SSH/pull/507
+[#516]: https://github.com/RustCrypto/SSH/pull/516
+[#530]: https://github.com/RustCrypto/SSH/pull/530
+[#533]: https://github.com/RustCrypto/SSH/pull/533
+[#534]: https://github.com/RustCrypto/SSH/pull/534
+[#535]: https://github.com/RustCrypto/SSH/pull/535
+[#537]: https://github.com/RustCrypto/SSH/pull/537
+[#557]: https://github.com/RustCrypto/SSH/pull/557
+[#560]: https://github.com/RustCrypto/SSH/pull/560
+
 ## 0.2.0 (2023-08-11)
 - Initial release
 

--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssh-cipher"
-version = "0.3.0-rc.10"
+version = "0.3.0"
 description = """
 Pure Rust implementation of SSH symmetric encryption including support for the modern
 aes128-gcm@openssh.com/aes256-gcm@openssh.com and chacha20-poly1305@openssh.com algorithms as well

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -17,20 +17,10 @@ readme = "README.md"
 edition = "2024"
 rust-version = "1.85"
 
-# ssh-cipher
-[dependencies.cipher]
-version = "0.3.0-rc.10"
-package = "ssh-cipher"
-features = ["encoding", "zeroize"]
-
-# ssh-encoding
-[dependencies.encoding]
-version = "0.3"
-package = "ssh-encoding"
-features = ["base64", "digest", "pem", "ctutils", "zeroize"]
-
 [dependencies]
+cipher = { package = "ssh-cipher", version = "0.3", features = ["encoding", "zeroize"] }
 ctutils = { version = "0.4", default-features = false }
+encoding = { package = "ssh-encoding", version = "0.3", features = ["base64", "digest", "pem", "ctutils", "zeroize"] }
 sha2 = { version = "0.11", default-features = false }
 signature = { version = "3", default-features = false }
 zeroize = { version = "1.9", default-features = false }


### PR DESCRIPTION
## Added
- `Decryptor` and `Encryptor` ([#253], [#533], [#534])
- `ChaCha20Poly1305` implementing SSH-flavored construction with `aead` API ([#256], [#370])
- `zeroize` feature ([#283])
- `core::error::Error` support ([#303])
- `getrandom` and `rand_core` feature passthroughs ([#535])
- `encoding` feature ([#560])

## Changed
- Upgrade to 2024 edition; MSRV 1.85 ([#354])
- Migrate from `subtle` to `ctutils` ([#507])
- Consolidate `aes` feature instead of per-block-mode features ([#530])
- Upgrade low-level symmetric crypto dependencies ([#516])
  - `aes` v0.9
  - `ctr` v0.10
  - `chacha20` v0.10
  - `des` v0.9
  - `poly1305` v0.9
- Upgrade `ssh-encoding` to v0.3 ([#537])
- Upgrade AEAD dependencies ([#557])
  - `aead` 0.6
  - `aes-gcm` v0.11

## Removed
- `std` feature ([#303])

[#253]: https://github.com/RustCrypto/SSH/pull/253
[#256]: https://github.com/RustCrypto/SSH/pull/256
[#283]: https://github.com/RustCrypto/SSH/pull/283
[#303]: https://github.com/RustCrypto/SSH/pull/303
[#354]: https://github.com/RustCrypto/SSH/pull/354
[#370]: https://github.com/RustCrypto/SSH/pull/370
[#507]: https://github.com/RustCrypto/SSH/pull/507
[#516]: https://github.com/RustCrypto/SSH/pull/516
[#530]: https://github.com/RustCrypto/SSH/pull/530
[#533]: https://github.com/RustCrypto/SSH/pull/533
[#534]: https://github.com/RustCrypto/SSH/pull/534
[#535]: https://github.com/RustCrypto/SSH/pull/535
[#537]: https://github.com/RustCrypto/SSH/pull/537
[#557]: https://github.com/RustCrypto/SSH/pull/557
[#560]: https://github.com/RustCrypto/SSH/pull/560