### PR TITLE
ssh-cipher: add `encoding` feature

### DIFF
--- a/ssh-cipher/Cargo.toml
+++ b/ssh-cipher/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.85"
 
 [dependencies]
 cipher = "0.5"
-encoding = { package = "ssh-encoding", version = "0.3" }
 
 # optional dependencies
 aead = { version = "0.6", optional = true, default-features = false }
@@ -28,6 +27,7 @@ aes-gcm = { version = "0.11", optional = true, default-features = false, feature
 ctutils = { version = "0.4", optional = true, default-features = false }
 chacha20 = { version = "0.10", optional = true, default-features = false, features = ["cipher", "legacy"] }
 des = { version = "0.9", optional = true, default-features = false }
+encoding = { package = "ssh-encoding", version = "0.3", optional = true }
 poly1305 = { version = "0.9", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -37,6 +37,7 @@ hex-literal = "1"
 [features]
 aes = ["dep:aead", "dep:aes", "dep:aes-gcm"]
 chacha20poly1305 = ["dep:aead", "dep:chacha20", "dep:poly1305", "dep:ctutils"]
+encoding = ["dep:encoding"]
 getrandom = ["rand_core", "aead?/getrandom", "cipher/getrandom"]
 rand_core = ["aead?/rand_core", "cipher/rand_core"]
 tdes = ["dep:des"]

--- a/ssh-cipher/src/lib.rs
+++ b/ssh-cipher/src/lib.rs
@@ -21,7 +21,6 @@ pub use crate::chacha20poly1305::{ChaCha20, ChaCha20Poly1305, ChaChaKey, ChaChaN
 
 use cipher::array::{Array, typenum::U16};
 use core::{fmt, str};
-use encoding::{Label, LabelError};
 
 #[cfg(feature = "aes")]
 use self::block_cipher::Aes;
@@ -29,6 +28,8 @@ use self::block_cipher::Aes;
 use self::block_cipher::Tdes;
 #[cfg(any(feature = "aes", feature = "chacha20poly1305"))]
 use ::aead::{AeadInOut, KeyInit};
+#[cfg(feature = "encoding")]
+use encoding::{Label, LabelError};
 #[cfg(any(feature = "aes", feature = "tdes"))]
 use {
     self::block_cipher::{BlockMode, sealed::BlockCipher},
@@ -163,6 +164,7 @@ impl Cipher {
     ///
     /// # Errors
     /// Returns [`LabelError`] if the provided `ciphername` is unknown.
+    #[cfg(feature = "encoding")]
     pub fn new(ciphername: &str) -> core::result::Result<Self, LabelError> {
         ciphername.parse()
     }
@@ -472,6 +474,7 @@ impl AsRef<str> for Cipher {
     }
 }
 
+#[cfg(feature = "encoding")]
 impl Label for Cipher {}
 
 impl fmt::Display for Cipher {
@@ -480,6 +483,7 @@ impl fmt::Display for Cipher {
     }
 }
 
+#[cfg(feature = "encoding")]
 impl str::FromStr for Cipher {
     type Err = LabelError;
 

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.85"
 [dependencies.cipher]
 version = "0.3.0-rc.10"
 package = "ssh-cipher"
-features = ["zeroize"]
+features = ["encoding", "zeroize"]
 
 # ssh-encoding
 [dependencies.encoding]


### PR DESCRIPTION
Makes `ssh-encoding` support optional, for anyone who implements their own support for the SSH packet format and just wants to use the cryptographic aspects of this crate.