### PR TITLE
ssh-key: bump `p256`/`p384`/`p521` to v0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.23"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa0176db12735e38bffeaa3c19ba4470216007496b2088632369bcee6eb5069"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
  "digest",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478aa2e499c7164b21b4c5e8610018e5b83a284da5f9e0896907dd4749cd76c9"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "primefield",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "wnaf"
-version = "0.14.0-rc.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfae175ab8f55e3c604de329bf66f628274c2cda893923670a73ebd1958ead2"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
  "ff",
  "group",

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -32,9 +32,9 @@ dsa = { version = "0.7", optional = true, default-features = false, features = [
 ed25519-dalek = { version = "3", optional = true, default-features = false }
 hex = { version = "0.4", optional = true, default-features = false, features = ["alloc"] }
 hmac = { version = "0.13", optional = true }
-p256 = { version = "0.14.0-rc.15", optional = true, default-features = false, features = ["ecdsa"] }
-p384 = { version = "0.14.0-rc.15", optional = true, default-features = false, features = ["ecdsa"] }
-p521 = { version = "0.14.0-rc.15", optional = true, default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.14", optional = true, default-features = false, features = ["ecdsa"] }
+p384 = { version = "0.14", optional = true, default-features = false, features = ["ecdsa"] }
+p521 = { version = "0.14", optional = true, default-features = false, features = ["ecdsa"] }
 rand_core = { version = "0.10", optional = true, default-features = false }
 rsa = { version = "0.10.0-rc.18", optional = true, default-features = false, features = ["sha2"] }
 sec1 = { version = "0.8", optional = true, default-features = false, features = ["point"] }


### PR DESCRIPTION
Release PRs:
- `p256` v0.14.0: RustCrypto/elliptic-curves#1890
- `p384` v0.14.0: RustCrypto/elliptic-curves#1892
- `p521` v0.14.0: RustCrypto/elliptic-curves#1902