### PR TITLE
ssh-key: fix doc comment for HashAlg::new

### DIFF
--- a/ssh-key/src/algorithm.rs
+++ b/ssh-key/src/algorithm.rs
@@ -425,7 +425,7 @@ pub enum HashAlg {
 }
 
 impl HashAlg {
-    /// Decode elliptic curve from the given string identifier.
+    /// Decode hash algorithm from the given string identifier.
     ///
     /// # Supported hash algorithms
     ///


### PR DESCRIPTION
Fixes a doc comment copy/paste mistake in `HashAlg::new` by replacing "elliptic curve" with "hash algorithm".