### PR TITLE
ssh-key: bump `argon2` to v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.6.0-rc.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
 dependencies = [
  "base64ct",
  "blake2",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
  "digest",
 ]

--- a/ssh-key/Cargo.toml
+++ b/ssh-key/Cargo.toml
@@ -26,7 +26,7 @@ signature = { version = "3", default-features = false }
 zeroize = { version = "1.9", default-features = false }
 
 # optional dependencies
-argon2 = { version = "0.6.0-rc.8", optional = true, default-features = false, features = ["alloc"] }
+argon2 = { version = "0.6", optional = true, default-features = false, features = ["alloc"] }
 bcrypt-pbkdf = { version = "0.11", optional = true, default-features = false, features = ["alloc"] }
 dsa = { version = "0.7", optional = true, default-features = false, features = ["hazmat"] }
 ed25519-dalek = { version = "3", optional = true, default-features = false }


### PR DESCRIPTION
Release PR: RustCrypto/password-hashes#931